### PR TITLE
fix(markdown): inline code has high precedence

### DIFF
--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -125,6 +125,46 @@ let inline =
         [ ( "normal"
           , `Quick
           , check_aux "`codes here`" (Paragraph [ I.Code "codes here" ]) )
+        ; ( "overlap-with-emphasis"
+          , `Quick
+          , check_aux "*aa`*`" (Paragraph [ I.Plain "*aa"; I.Code "*" ]) )
+        ; ( "overlap-with-emphasis-2"
+          , `Quick
+          , check_aux "**aa`**`" (Paragraph [ I.Plain "**aa"; I.Code "**" ]) )
+        ; ( "overlap-with-emphasis-3"
+          , `Quick
+          , check_aux "_a`_`" (Paragraph [ I.Plain "_a"; I.Code "_" ]) )
+        ; ( "overlap-with-emphasis-4"
+          , `Quick
+          , check_aux "__a`__`" (Paragraph [ I.Plain "__a"; I.Code "__" ]) )
+        ; ( "overlap-with-emphasis-5"
+          , `Quick
+          , check_aux "`as*d`*" (Paragraph [ I.Code "as*d"; I.Plain "*" ]) )
+        ] )
+  ; ( "emphasis"
+    , testcases
+        [ ( "normal"
+          , `Quick
+          , check_aux "*abc*"
+              (Paragraph [ I.Emphasis (`Italic, [ Plain "abc" ]) ]) )
+        ; ( "normal-2"
+          , `Quick
+          , check_aux "**abc**"
+              (Paragraph [ I.Emphasis (`Bold, [ Plain "abc" ]) ]) )
+        ; ( "inline-code-inside"
+          , `Quick
+          , check_aux "*asd`qwe`*"
+              (Paragraph
+                 [ I.Emphasis (`Italic, [ I.Plain "asd"; I.Code "qwe" ]) ]) )
+        ; ( "inline-code-inside-2"
+          , `Quick
+          , check_aux "***asd`qwe`***"
+              (Paragraph
+                 [ I.Emphasis
+                     ( `Italic
+                     , [ I.Emphasis (`Bold, [ I.Plain "asd"; I.Code "qwe" ]) ]
+                     )
+                 ]) )
         ] )
   ]
 

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -34,6 +34,34 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
+        ; ( "normal-2"
+          , `Quick
+          , check_aux "[test  normal](http://testtest/asdasd)"
+              (Paragraph
+                 [ I.Link
+                     { url =
+                         I.Complex
+                           { protocol = "http"; link = "//testtest/asdasd" }
+                     ; label = [ Plain "test  normal" ]
+                     ; title = None
+                     ; full_text = "[test  normal](http://testtest/asdasd)"
+                     ; metadata = ""
+                     }
+                 ]) )
+        ; ( "inline-code-in-label"
+          , `Quick
+          , check_aux "[test `normal`](http://testtest/asdasd)"
+              (Paragraph
+                 [ I.Link
+                     { url =
+                         I.Complex
+                           { protocol = "http"; link = "//testtest/asdasd" }
+                     ; label = [ Plain "test "; Code "normal" ]
+                     ; title = None
+                     ; full_text = "[test `normal`](http://testtest/asdasd)"
+                     ; metadata = ""
+                     }
+                 ]) )
         ; ( "with-*"
           , `Quick
           , check_aux "http://testtest/asd*asd"
@@ -140,6 +168,25 @@ let inline =
         ; ( "overlap-with-emphasis-5"
           , `Quick
           , check_aux "`as*d`*" (Paragraph [ I.Code "as*d"; I.Plain "*" ]) )
+        ; ( "overlap-with-link"
+          , `Quick
+          , check_aux "[as`d](`http://dwdw)"
+              (Paragraph
+                 [ I.Plain "[as"
+                 ; I.Code "d]("
+                 ; I.Link
+                     { url = Complex { protocol = "http"; link = "//dwdw" }
+                     ; label = [ Plain "http://dwdw" ]
+                     ; title = None
+                     ; full_text = "http://dwdw"
+                     ; metadata = ""
+                     }
+                 ; I.Plain ")"
+                 ]) )
+        ; ( "overlap-with-link-2"
+          , `Quick
+          , check_aux "[as`d](http://dwdw)`"
+              (Paragraph [ I.Plain "[as"; I.Code "d](http://dwdw)" ]) )
         ] )
   ; ( "emphasis"
     , testcases


### PR DESCRIPTION
Inline code has higher precedence than any other inline constructs except HTML tags and autolinks(quicklinks)