### PR TITLE
fix(markdown): multiple-line quote&example isn't correctly displayed

### DIFF
--- a/lib/parsers.ml
+++ b/lib/parsers.ml
@@ -222,7 +222,7 @@ let rec at_most m p =
 let limits n m p = lift2 (fun xs ys -> xs @ ys) (count n p) (at_most m p)
 
 let lines_while p =
-  let line = p <* optional eol in
+  let line = p <* optional eol >>| fun s -> s ^ "\n" in
   many1 line
 
 let lines_starts_with p = lines_while ((spaces *> p <* spaces) *> optional_line)

--- a/lib/syntax/markdown_code_block.ml
+++ b/lib/syntax/markdown_code_block.ml
@@ -27,7 +27,9 @@ let single_line =
   lift2 (fun indent content -> (indent, content)) spaces line
 
 let parse =
-  many1 (single_line <* (end_of_line <|> end_of_input) <* optional eols)
+  many1
+    ( single_line <* (end_of_line <|> end_of_input) <* optional eols
+    >>| fun (indent, s) -> (indent, s ^ "\n") )
   >>= fun lines ->
   let start_indent, _content = List.hd lines in
   let lines =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -225,6 +225,26 @@ let block =
           , check_aux "[^abc]: 中文"
               (Footnote_Definition ("abc", [ I.Plain "中文" ])) )
         ] )
+  ; ( "quote"
+    , testcases
+        [ ( "multi lines"
+          , `Quick
+          , check_aux ">foo\n>bar"
+              (Quote
+                 [ Paragraph
+                     [ I.Plain "foo"
+                     ; I.Break_Line
+                     ; I.Plain "bar"
+                     ; I.Break_Line
+                     ]
+                 ]) )
+        ] )
+  ; ( "example"
+    , testcases
+        [ ( "multi lines"
+          , `Quick
+          , check_aux "    foo\n    bar" (Example [ "foo\n"; "bar\n" ]) )
+        ] )
   ]
 
 let () = Alcotest.run "mldoc" @@ List.concat [ inline; block ]

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -25,6 +25,27 @@ let block =
           , check_aux "[fn:abc] 中文"
               (Footnote_Definition ("abc", [ I.Plain "中文" ])) )
         ] )
+  ; ( "quote"
+    , testcases
+        [ ( "multi lines"
+          , `Quick
+          , check_aux "#+BEGIN_QUOTE\nfoo\nbar\n#+END_QUOTE"
+              (Quote
+                 [ Paragraph
+                     [ I.Plain "foo"
+                     ; I.Break_Line
+                     ; I.Plain "bar"
+                     ; I.Break_Line
+                     ]
+                 ]) )
+        ] )
+  ; ( "example"
+    , testcases
+        [ ( "multi lines"
+          , `Quick
+          , check_aux "#+BEGIN_EXAMPLE\nfoo\nbar\n#+END_EXAMPLE"
+              (Example [ "foo"; "\n"; "bar"; "\n" ]) )
+        ] )
   ]
 
 let () = Alcotest.run "mldoc" @@ List.concat [ block ]


### PR DESCRIPTION
related to https://github.com/logseq/logseq/issues/1438