### PR TITLE
enhance: macro args parsing

### DIFF
--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -115,6 +115,24 @@ let inline =
                  [ I.Macro
                      { I.Macro.name = "embed"; arguments = [ "[[page]]" ] }
                  ]) )
+        ; ( "args"
+          , `Quick
+          , check_aux "{{macroname [[A,B]], ((C,D)), E}}"
+              (Paragraph
+                 [ I.Macro
+                     { I.Macro.name = "macroname"
+                     ; arguments = [ "[[A,B]]"; "((C,D))"; "E" ]
+                     }
+                 ]) )
+        ; ( "args-2"
+          , `Quick
+          , check_aux "{{macroname ([[A,B]], ((C,D)), E)}}"
+              (Paragraph
+                 [ I.Macro
+                     { I.Macro.name = "macroname"
+                     ; arguments = [ "[[A,B]]"; "((C,D))"; "E" ]
+                     }
+                 ]) )
         ] )
   ; ( "drawer"
     , testcases


### PR DESCRIPTION
parse `{{macro [[foo,bar]]}}` into `Macro {name="macro", args=["[[foo,bar]]"]}`,
instead of breaking `[[foo,bar]]` into `["[[foo";"bar]]"]`