### PR TITLE
fix: page-ref before markdown-link

### DIFF
--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -621,13 +621,17 @@ let markdown_link config =
     label_part link_url_part metadata
 
 let markdown_link_or_page_ref config =
-  (markdown_link config)
-  <|>
-  (page_ref >>| fun s ->
-   let inner_s = String.sub s 2 (String.length s - 4) in
-    Link
-     {url = Search inner_s; label = [Plain ""]; title = None;
-      full_text = s; metadata = ""})
+  page_ref
+  >>| (fun s ->
+        let inner_s = String.sub s 2 (String.length s - 4) in
+        Link
+          { url = Search inner_s
+          ; label = [ Plain "" ]
+          ; title = None
+          ; full_text = s
+          ; metadata = ""
+          })
+  <|> markdown_link config
 
 let link config =
   match config.format with

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -235,6 +235,25 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
+        ; ( "page-ref before link"
+          , `Quick
+          , check_aux "[[a]][b](c)"
+              (Paragraph
+                 [ I.Link
+                     { url = I.Search "a"
+                     ; label = [ Plain "" ]
+                     ; title = None
+                     ; full_text = "[[a]]"
+                     ; metadata = ""
+                     }
+                 ; I.Link
+                     { url = I.Search "c"
+                     ; label = [ Plain "b" ]
+                     ; title = None
+                     ; full_text = "[b](c)"
+                     ; metadata = ""
+                     }
+                 ]) )
         ] )
   ; ( "inline-macro"
     , testcases
@@ -254,8 +273,11 @@ let inline =
           , `Quick
           , check_aux "{{query (and [[test]])}}"
               (Paragraph
-                 [ I.Macro { I.Macro.name = "query"; arguments = [ "(and [[test]])" ] } ])
-          )
+                 [ I.Macro
+                     { I.Macro.name = "query"
+                     ; arguments = [ "(and [[test]])" ]
+                     }
+                 ]) )
         ; ( "embed"
           , `Quick
           , check_aux "{{{embed [[page]]}}}"


### PR DESCRIPTION
related to https://github.com/logseq/logseq/issues/1546