### PR TITLE
Feat/mixed heading

### DIFF
--- a/lib/document.ml
+++ b/lib/document.ml
@@ -113,7 +113,18 @@ let from_ast filename ast =
       | Directive (k, v) ->
         let directives = (k, v) :: directives in
         aut directives blocks toc tl
-      | Heading { title; tags; marker; level; priority; anchor; meta; unordered; _ } ->
+      | Heading
+          { title
+          ; tags
+          ; marker
+          ; level
+          ; priority
+          ; anchor
+          ; meta
+          ; unordered
+          ; size
+          ; numbering = _numbering
+          } ->
         let numbering = compute_heading_numbering level toc in
         let h =
           Heading
@@ -126,6 +137,7 @@ let from_ast filename ast =
             ; meta
             ; numbering = Some numbering
             ; unordered
+            ; size
             }
         in
         let toc_item = { title; level; anchor; numbering; items = [] } in

--- a/lib/mldoc_parser.ml
+++ b/lib/mldoc_parser.ml
@@ -47,7 +47,8 @@ let parsers config =
 
 let parse config input =
   match parse_string ~consume:All (parsers config) input with
-  | Ok result -> Paragraph.concat_paragraph_lines config result
+  | Ok result ->
+    Paragraph.concat_paragraph_lines config result |> Reset_level.reset
   | Error err -> failwith err
 
 let load_file f =

--- a/lib/reset_level.ml
+++ b/lib/reset_level.ml
@@ -1,0 +1,36 @@
+type state =
+  { indent : [ `Must of int | `Maybe of int ] option
+  ; indent_threshold : int
+  }
+
+let empty_state = { indent = None; indent_threshold = 0 }
+
+let update_level (state, r) (t, pos) =
+  match t with
+  | Type.Heading h -> (
+    match (h.unordered, state.indent) with
+    | true, Some (`Maybe indent') when h.level <= indent' ->
+      ( { indent = Some (`Must indent'); indent_threshold = h.level }
+      , (Type.Heading { h with level = h.level + indent' }, pos) :: r )
+    | true, Some (`Maybe _) -> (empty_state, (t, pos) :: r)
+    | true, Some (`Must indent') when h.level >= state.indent_threshold ->
+      (state, (Type.Heading { h with level = h.level + indent' }, pos) :: r)
+    | true, Some (`Must _indent') -> (empty_state, (t, pos) :: r)
+    | true, None -> (empty_state, (t, pos) :: r)
+    | false, _ ->
+      ( { indent = Some (`Maybe 4); indent_threshold = 0 }
+      , (Type.Heading { h with level = 1 }, pos) :: r ))
+  | _ -> (state, (t, pos) :: r)
+
+(* reset Heading's level
+   ---
+   ## AA (reset level=1)
+   - BB (reset level=1+4)
+       - CC (reset level=5+4)
+   #### DD (reset level=1)
+       - EE (level=5, unchanged)
+   - FF (level=1, unchanged)
+   ---
+   *)
+let reset (tl : (Type.t * Type.pos_meta) list) =
+  List.fold_left update_level (empty_state, []) tl |> snd |> List.rev

--- a/lib/syntax/extended/hash_tag.ml
+++ b/lib/syntax/extended/hash_tag.ml
@@ -6,13 +6,13 @@ let tag_delims = [ ','; ';'; '.'; '!'; '?'; '\''; '"'; ':' ]
 let hashtag_name =
   let hashtag_name_part =
     take_while1 (fun c ->
-        non_space_eol c && (not (List.mem c tag_delims)) && c <> '[')
+        non_space_eol c && (not (List.mem c tag_delims)) && c <> '[' && c <> '#')
     <|> page_ref
     (* ignore last consecutive periods *)
     <|> ( take_while (fun c -> List.mem c tag_delims)
           *> (satisfy is_space_eol *> return () <|> end_of_input)
           *> return `Finish
-        <|> (any_char_string >>| fun c -> `Continue c)
+        <|> (String.make 1 <$> not_one_of [ '#' ] >>| fun c -> `Continue c)
         >>= fun r ->
           match r with
           | `Finish -> fail "hashtag_name_part finish"

--- a/lib/syntax/markdown_level.ml
+++ b/lib/syntax/markdown_level.ml
@@ -1,3 +1,4 @@
 open Angstrom
+open Parsers
 
-let parse = take_while1 (fun c -> c = '#')
+let parse = optional ws *> take_while1 (fun c -> c = '#')

--- a/lib/syntax/type.ml
+++ b/lib/syntax/type.ml
@@ -15,7 +15,8 @@ type heading =
   ; priority : char option [@default None]  (** The optional priority *)
   ; anchor : string
   ; meta : meta
-  ; unordered: bool             (** whether it's an unordered list (starts with `-`) **)
+  ; unordered : bool  (** whether it's an unordered list (starts with `-`) **)
+  ; size : int option [@default None]
   }
 [@@deriving yojson]
 

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -748,6 +748,39 @@ let block =
                   }
               ] )
         ] )
+  ; ( "- # mixed heading"
+    , testcases
+        [ ( "case 1"
+          , `Quick
+          , check_aux "- ## test"
+              (Heading
+                 { title = [ Inline.Plain "test" ]
+                 ; tags = []
+                 ; marker = None
+                 ; level = 1
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = "test"
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = Some 2
+                 }) )
+        ; ( "case 2"
+          , `Quick
+          , check_aux "    - ## TODO test"
+              (Heading
+                 { title = [ Inline.Plain "test" ]
+                 ; tags = []
+                 ; marker = Some "TODO"
+                 ; level = 5
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = "test"
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = Some 2
+                 }) )
+        ] )
   ]
 
 let () = Alcotest.run "mldoc" @@ List.concat [ inline; block ]

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -10,9 +10,24 @@ let default_config : Conf.t =
 let check_mldoc_type =
   Alcotest.check (Alcotest.testable Type.pp ( = )) "check mldoc type"
 
+let check_mldoc_type_list =
+  Alcotest.check
+    (Alcotest.testable
+       (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          Type.pp)
+       ( = ))
+    "check mldoc type list"
+
 let check_aux source expect =
   let result = Mldoc.Parser.parse default_config source |> List.hd |> fst in
   fun _ -> check_mldoc_type expect result
+
+let check_list_aux source expect =
+  let result =
+    Mldoc.Parser.parse default_config source |> List.map (fun (t, _pos) -> t)
+  in
+  fun _ -> check_mldoc_type_list expect result
 
 let testcases =
   List.map (fun (case, level, f) -> Alcotest.test_case case level f)
@@ -521,6 +536,217 @@ let block =
           , `Quick
           , check_aux "\\begin{equation}[a,b,c] x=\\sqrt{b} \\end{equation}"
               (Latex_Environment ("equation", None, "[a,b,c] x=\\sqrt{b} ")) )
+        ] )
+  ; ( "reset levels"
+    , testcases
+        [ ( "case1"
+          , `Quick
+            (*
+               ## A    (level 1)
+               - B     (level 5)
+                   - C (level 9)
+               #### D  (level 1)
+                   - E (level 5)
+               - F     (level 1)
+            *)
+          , check_list_aux "## A\n- B\n    - C\n#### D\n    - E\n- F"
+              [ Type.Heading
+                  { Type.title = [ Inline.Plain "A" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "A"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = false
+                  ; size = Some 2
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "B" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "B"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "C" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 9
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "C"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "D" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "D"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = false
+                  ; size = Some 4
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "E" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "E"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "F" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "F"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ] )
+        ; ( "case2"
+          , `Quick
+            (*
+- A     (level 1)
+## B    (level 1)
+- C     (level 5)
+- D     (level 5)
+    - E (level 9)
+- F     (level 5)
+### G   (level 1)
+    - H (level 5)
+- I     (level 1)
+            *)
+          , check_list_aux
+              "- A\n## B\n- C\n- D\n    - E\n- F\n### G\n    - H\n- I"
+              [ Type.Heading
+                  { Type.title = [ Inline.Plain "A" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "A"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "B" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "B"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = false
+                  ; size = Some 2
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "C" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "C"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "D" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "D"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "E" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 9
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "E"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "F" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "F"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "G" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "G"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = false
+                  ; size = Some 3
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "H" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 5
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "H"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ; Type.Heading
+                  { Type.title = [ Inline.Plain "I" ]
+                  ; tags = []
+                  ; marker = None
+                  ; level = 1
+                  ; numbering = None
+                  ; priority = None
+                  ; anchor = "I"
+                  ; meta = { Type.timestamps = []; properties = [] }
+                  ; unordered = true
+                  ; size = None
+                  }
+              ] )
         ] )
   ]
 


### PR DESCRIPTION
1. sort headings‘ levels
```
- A     (level 1,size=none)
## B    (level 2->1,size=2)
- C     (level 1->5,size=none)
- D     (level 1->5,size=none)
    - E (level 5->9,size=none)
- F     (level 1->5,size=none)
### G   (level 3->1,size=3)
    - H (level 5,size=none)
- I     (level 1,size=none)
```

2. support syntax like `- ### title` level=1 and size=3