### PR TITLE
Refactor/export md using tree type

### DIFF
--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -321,9 +321,10 @@ and list refs state config l =
       l)
   @@ List.flatten
   @@ CCList.map
-       (fun { content; items; number; name; checkbox; indent; _ } ->
+       (fun { content; items; number; name; checkbox; _ } ->
+         let state' = { state with current_level = state.current_level + 1 } in
          let name' = flatten_map (inline refs state config) name in
-         let content' = flatten_map (block refs state config) content in
+         let content' = flatten_map (block refs state' config) content in
          (* Definition Lists content if name isn't empty  *)
          let content'' =
            if name' <> [] then
@@ -332,7 +333,7 @@ and list refs state config l =
                   (fun l ->
                     List.flatten
                       [ [ raw_text ": " ]
-                      ; block refs state config l
+                      ; block refs state' config l
                       ; [ newline ]
                       ])
                   content
@@ -354,9 +355,8 @@ and list refs state config l =
            | Some true -> raw_text "[X]"
            | Some false -> raw_text "[ ]"
            | None -> raw_text ""
-         and indent' =
-           raw_text @@ String.make ((2 * state.current_level) + indent) ' '
-         and items' = list refs state config items in
+         and indent' = raw_text @@ String.make state'.current_level '\t'
+         and items' = list refs state' config items in
          List.flatten
            [ [ indent' ]
            ; [ number' ]

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -2,7 +2,6 @@ open Prelude
 open Type
 open Inline
 open Document
-open Reference
 open Conf
 open Output
 

--- a/lib/export/opml.ml
+++ b/lib/export/opml.ml
@@ -21,7 +21,7 @@ let rec block_tree_to_plain_tree (blocks : Tree_type.value) : string Zip.l =
   | Leaf (t, _pos) ->
     leaf
       Markdown.(
-        to_string default_config
+        Output.to_string
         @@ block empty_references (default_state ()) default_config t)
   | Branch [] -> Branch []
   | Branch l -> branch @@ CCList.map block_tree_to_plain_tree l

--- a/lib/export/output.ml
+++ b/lib/export/output.ml
@@ -1,0 +1,312 @@
+open Prelude
+
+type t =
+  | RawText of string
+  | Space  (** merge adjacent multiple Space as one Space *)
+  | Newline  (** merge adjacent multiple Newline as one Newline *)
+  | TwoNewlines
+  | OneNewline  (** merge_adjacent_space_newline internal use *)
+  | Indent of (int * int)  (** indent (num of tabs, num of spaces after tabs) *)
+
+(* 1.  [...;space; space]         -> [...;space]
+   2.  [...;newline;newline]      -> [...;newline]
+   3.  [...;space; newline]       -> [...;newline]
+   4.  [...;newline;space]        -> [...;newline]
+   5.  [...;"XXX\n";space]        -> [...;"XXX\n"]
+   6.  [...;space;"\nXXX"]        -> [...;"\nXXX"]
+   7.  [...;"XXX\n";newline]      -> [...;"XXX\n"]
+   8.  [...;newline;"\nXXX"]      -> [...;"\nXXX"]
+   9.  [...;"XXX<space>";space]   -> [...;"XXX<space>"]
+   10. [...;space;"<space>XXX"]   -> [...;"<space>XXX"]
+   11. [...;"XXX<space>";newline] -> [...;"XXX<space>";newline]
+   12. [...;space;"XXX"]          -> [...;space;"XXX"]
+   13. [...;newline;"XXX"]        -> [...;newline;"XXX"]
+   14. [...;space;indent]         -> [...;indent]
+   15. [...;indent;indent]        -> [...;indent]
+   16. [...;newline;indent]       -> [...;newline;indent]
+   17. [...;indent;space]         -> [...;indent]
+   18. [...;indent;newline]       -> [...;newline]
+   19. [...;"XXX\n";indent]       -> [...;"XXX\n";indent]
+   20. [...;"XXX<space>";indent]  -> [...;"XXX<space>"]
+   21. [...;indent;"XXX"]         -> [...;indent;"XXX"]
+   22. [...;indent;"\nXXX"]       -> [...;"\nXXX"]
+   23. [...;"XXX";indent]         -> [...;"XXX"] // XXX is not endwith '\n'
+ * *)
+let merge_adjacent_space_newline =
+  let suffix_newline_num s =
+    let len = String.length s in
+    if len = 0 then
+      None
+    else if len = 1 && s.[0] = '\n' then
+      Some 1
+    else if len > 1 && s.[len - 1] = '\n' && s.[len - 2] = '\n' then
+      Some 2
+    else if len > 1 && s.[len - 1] = '\n' then
+      Some 1
+    else
+      None
+  in
+  let to_t = function
+    | `Space -> Space
+    | `Newline -> Newline
+    | `TwoNewlines -> TwoNewlines
+    | `OneNewline -> OneNewline
+    | `Indent n -> Indent n
+  in
+  fun tl ->
+    List.rev
+    @@ (fun (r, _, _, _, _) -> r)
+    @@ List.fold_left
+         (fun ( result
+              , before
+              , before_space_text
+              , before_newline_text
+              , start_of_line ) e ->
+           match
+             (e, before, before_space_text, before_newline_text, start_of_line)
+           with
+           | Space, _, _, Some _, _ ->
+             (* 5 *) (result, [], false, before_newline_text, start_of_line)
+           | Space, _, true, None, _ ->
+             (* 9 *) (result, [], true, None, start_of_line)
+           | Space, `Space :: _, false, None, _ ->
+             (* 1 *)
+             (result, [ `Space ], false, None, start_of_line)
+           | Space, `Newline :: _, false, None, _ ->
+             (* 4 *)
+             (result, [ `Newline ], false, None, start_of_line)
+           | Space, `Indent n :: _, false, None, _ ->
+             (* 17 *)
+             (result, [ `Indent n ], false, None, start_of_line)
+           | Space, `OneNewline :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, start_of_line)
+           | Space, `TwoNewlines :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, start_of_line)
+           | Space, [], false, None, _ ->
+             (* 12 *)
+             (result, [ `Space ], false, None, start_of_line)
+           | Newline, _, _, Some _, _ ->
+             (*  7 *) (result, [], false, before_newline_text, true)
+           | Newline, _, true, None, _ ->
+             (* 11 *)
+             (result, [ `Newline ], false, None, true)
+           | Newline, `Space :: _, false, None, _ ->
+             (* 3 *)
+             (result, [ `Newline ], false, None, true)
+           | Newline, `Newline :: _, false, None, _ ->
+             (* 2 *)
+             (result, [ `Newline ], false, None, true)
+           | Newline, `Indent _ :: _, false, None, _ ->
+             (* 18 *)
+             (result, [ `Newline ], false, None, true)
+           | Newline, `OneNewline :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | Newline, `TwoNewlines :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | Newline, [], false, None, _ ->
+             (result, [ `Newline ], false, None, true)
+           | OneNewline, _, _, Some _, _ ->
+             (* before_newline_text can't erase OneNewline *)
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, _, true, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, `Space :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, `Newline :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, `Indent _ :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, `TwoNewlines :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | OneNewline, `OneNewline :: _, false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | OneNewline, [], false, None, _ ->
+             (result, [ `OneNewline ], false, None, true)
+           | TwoNewlines, _, _, Some 2, _ ->
+             (result, [], false, before_newline_text, true)
+           | TwoNewlines, _, _, Some _, _ ->
+             (result, [ `OneNewline ], false, before_newline_text, true)
+           | TwoNewlines, _, true, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, `Space :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, `Newline :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, `Indent _ :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, `OneNewline :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, `TwoNewlines :: _, false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | TwoNewlines, [], false, None, _ ->
+             (result, [ `TwoNewlines ], false, None, true)
+           | Indent (0, _), a, b, c, _ ->
+             (* ignore *)
+             (result, a, b, c, start_of_line)
+           | Indent n, before, _, _, true ->
+             ( CCList.append (CCList.map to_t before) result
+             , [ `Indent n ]
+             , false
+             , None
+             , false )
+           | Indent n, _, _, Some _, _ ->
+             (* 19 *)
+             (result, [ `Indent n ], false, None, start_of_line)
+           | Indent _, _, true, None, false ->
+             (* 20 *)
+             (result, before, true, None, start_of_line)
+           | Indent _, `Space :: _, false, None, false ->
+             (* 14 *)
+             (result, [ `Space ], false, None, start_of_line)
+           | Indent n, `Indent _ :: _, false, None, false ->
+             (* 15 *)
+             (result, [ `Indent n ], false, None, start_of_line)
+           | Indent n, `Newline :: _, false, None, false ->
+             (* 16 *)
+             (Newline :: result, [ `Indent n ], false, None, true)
+           | Indent n, `OneNewline :: _, false, None, false ->
+             (OneNewline :: result, [ `Indent n ], false, None, true)
+           | Indent n, `TwoNewlines :: _, false, None, false ->
+             (TwoNewlines :: result, [ `Indent n ], false, None, true)
+           | Indent _, [], false, None, false ->
+             (* 23 *)
+             (result, [], false, None, false)
+           | RawText "", _, _, _, _ ->
+             ( result
+             , before
+             , before_space_text
+             , before_newline_text
+             , start_of_line )
+           | RawText s, `Space :: _, _, _, _ when s.[0] = '\n' || s.[0] = ' ' ->
+             (* 6,10 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `Space :: _, _, _, _ ->
+             (* 12 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: Space :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `Newline :: _, _, _, _ when s.[0] = '\n' ->
+             (* 8 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `Newline :: _, _, _, _ ->
+             (* 13 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: Newline :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `OneNewline :: _, _, _, _ when s.[0] = '\n' ->
+             let last_char = s.[String.length s - 1] in
+             ( e :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `OneNewline :: _, _, _, _ ->
+             let last_char = s.[String.length s - 1] in
+             ( e :: OneNewline :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `TwoNewlines :: _, _, _, _ ->
+             let result =
+               if String.length s = 1 then
+                 if s.[0] = '\n' then
+                   TwoNewlines :: result
+                 else
+                   e :: TwoNewlines :: result
+               else if s.[0] = '\n' && s.[1] = '\n' then
+                 e :: result
+               else if s.[0] = '\n' then
+                 RawText (String.sub s 1 (String.length s - 1))
+                 :: TwoNewlines :: result
+               else
+                 e :: TwoNewlines :: result
+             in
+             let last_char = s.[String.length s - 1] in
+             ( result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `Indent _ :: _, _, _, _ when s.[0] = '\n' ->
+             (* 22 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, `Indent n :: _, _, _, _ ->
+             (* 21 *)
+             let last_char = s.[String.length s - 1] in
+             ( e :: Indent n :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' )
+           | RawText s, [], _, _, _ ->
+             let last_char = s.[String.length s - 1] in
+             ( e :: result
+             , []
+             , last_char = ' '
+             , suffix_newline_num s
+             , last_char = '\n' ))
+         ([], [ `Space ], false, None, true)
+         tl
+
+let remove_fst_space_newline = function
+  | [] -> []
+  | Space :: t -> t
+  | Newline :: t -> t
+  | l -> l
+
+(* let remove_greatest_common_prefix_indent config tl =
+ *   if not config.heading_to_list then
+ *     tl
+ *   else
+ *     let find_greatest_common_prefix_indent tl =
+ *       List.fold_left
+ *         (fun r e ->
+ *           match e with
+ *           | Indent n when n < r -> n
+ *           | _ -> r)
+ *         999 tl
+ *     in
+ *     let prefix = find_greatest_common_prefix_indent tl in
+ *     CCList.map
+ *       (fun e ->
+ *         match e with
+ *         | Indent n when n < prefix -> Indent 0
+ *         | Indent n -> Indent (n - prefix)
+ *         | _ -> e)
+ *       tl *)
+
+let to_string tl =
+  String.concat ""
+  @@ CCList.map
+       (function
+         | Space -> " "
+         | Newline -> "\n"
+         | TwoNewlines -> "\n\n"
+         | OneNewline -> "\n"
+         | Indent (tabs, spaces) ->
+           String.make tabs '\t' ^ String.make spaces ' '
+         | RawText s -> s)
+       (remove_fst_space_newline
+          (merge_adjacent_space_newline (merge_adjacent_space_newline tl)))

--- a/lib/export/output.ml
+++ b/lib/export/output.ml
@@ -276,27 +276,6 @@ let remove_fst_space_newline = function
   | Newline :: t -> t
   | l -> l
 
-(* let remove_greatest_common_prefix_indent config tl =
- *   if not config.heading_to_list then
- *     tl
- *   else
- *     let find_greatest_common_prefix_indent tl =
- *       List.fold_left
- *         (fun r e ->
- *           match e with
- *           | Indent n when n < r -> n
- *           | _ -> r)
- *         999 tl
- *     in
- *     let prefix = find_greatest_common_prefix_indent tl in
- *     CCList.map
- *       (fun e ->
- *         match e with
- *         | Indent n when n < prefix -> Indent 0
- *         | Indent n -> Indent (n - prefix)
- *         | _ -> e)
- *       tl *)
-
 let to_string tl =
   String.concat ""
   @@ CCList.map
@@ -306,7 +285,19 @@ let to_string tl =
          | TwoNewlines -> "\n\n"
          | OneNewline -> "\n"
          | Indent (tabs, spaces) ->
-           String.make tabs '\t' ^ String.make spaces ' '
+           let tabs' =
+             if tabs > 0 then
+               String.make tabs '\t'
+             else
+               ""
+           in
+           let spaces' =
+             if spaces > 0 then
+               String.make spaces ' '
+             else
+               ""
+           in
+           tabs' ^ spaces'
          | RawText s -> s)
        (remove_fst_space_newline
           (merge_adjacent_space_newline (merge_adjacent_space_newline tl)))

--- a/lib/export/output.ml
+++ b/lib/export/output.ml
@@ -140,7 +140,7 @@ let merge_adjacent_space_newline =
              (result, [ `TwoNewlines ], false, None, true)
            | TwoNewlines, [], false, None, _ ->
              (result, [ `TwoNewlines ], false, None, true)
-           | Indent (0, _), a, b, c, _ ->
+           | Indent (0, 0), a, b, c, _ ->
              (* ignore *)
              (result, a, b, c, start_of_line)
            | Indent n, before, _, _, true ->

--- a/lib/export/reference.ml
+++ b/lib/export/reference.ml
@@ -7,8 +7,10 @@ type t =
 [@@deriving yojson]
 
 type parsed_t =
-  { parsed_embed_blocks : (string * (Type.t list * Type.t list)) list
-  ; parsed_embed_pages : (string * Type.t list) list
+  { (** (block-uuid, (content-include-children, content)) list *)
+    parsed_embed_blocks : (string * (Type.t list * Type.t list)) list
+  ; (** (page-name, content) list *)
+    parsed_embed_pages : (string * Type.t list) list
   }
 
 let empty_parsed_t = { parsed_embed_blocks = []; parsed_embed_pages = [] }

--- a/lib/syntax/block.ml
+++ b/lib/syntax/block.ml
@@ -30,7 +30,8 @@ let displayed_math = string "$$" *> end_string "$$" (fun s -> Displayed_Math s)
  *   "age": 25
  * }
  * ``` *)
-let fenced_language = (string "```" <|> string "~~~") *> spaces *> optional line <* optional eol
+let fenced_language =
+  (string "```" <|> string "~~~") *> spaces *> optional line <* optional eol
 
 let fenced_code_block =
   fenced_language >>= fun language ->

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -312,7 +312,7 @@ let replace_macro (t : Type.t_with_pos_meta Z.t) expanded_macro macro =
     | Table _ -> t (* TODO: macro in table *)
     | _ -> t)
 
-let rec replace_embed_and_refs (t : Type.t_with_pos_meta Z.t) refs =
+let rec replace_embed_and_refs (t : Type.t_with_pos_meta Z.t) ~refs =
   let root = Z.of_l (to_value t) in
   let rec aux z =
     if Z.is_end z then
@@ -356,7 +356,7 @@ let rec replace_embed_and_refs (t : Type.t_with_pos_meta Z.t) refs =
           |> default z' |> aux
         | Type.Quote tl ->
           let t = of_blocks_without_pos tl in
-          let t' = replace_embed_and_refs t refs in
+          let t' = replace_embed_and_refs t ~refs in
           let tl' = to_blocks_without_pos t' in
           Z.replace z' ~item:(Z.Leaf (Type.Quote tl', Type.dummy_pos)) |> aux
         | Type.List items ->
@@ -367,7 +367,7 @@ let rec replace_embed_and_refs (t : Type.t_with_pos_meta Z.t) refs =
                 let content =
                   replace_embed_and_refs
                     (of_blocks_without_pos item.content)
-                    refs
+                    ~refs
                   |> to_blocks_without_pos
                 in
                 { item with content; items = nested_items_t })

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -255,17 +255,14 @@ let split_by_macro_or_block_ref inline_list macro_or_block_ref =
   | `Macro macro -> split_by_macro inline_list macro
   | `Block_ref s -> split_by_block_ref inline_list s
 
-(* TODO: zip.ml add insert_rights and insert_lefts  *)
 let insert_right z ~expanded_macro =
   match expanded_macro with
-  | Z.Branch l ->
-    CCList.fold_right (fun item z -> Z.insert_right z ~item |? z) l z
+  | Z.Branch items -> Z.insert_rights z ~items |? z
   | Z.Leaf _ as l -> Z.insert_right z ~item:l |? z
 
 let insert_right_block_ref z ~expanded_block_ref =
   match expanded_block_ref with
-  | Z.Branch l ->
-    CCList.fold_right (fun l z -> insert_right z ~expanded_macro:l) l z
+  | Z.Branch items -> Z.insert_rights z ~items |? z
   | Z.Leaf _ as l -> Z.insert_right z ~item:l |? z
 
 let replace_block_ref (t : Type.t_with_pos_meta Z.t) expanded_block_ref block_id

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -250,11 +250,6 @@ let split_by_block_ref inline_list block_ref =
   >>| fun (index, _) ->
   (CCList.take index inline_list, CCList.drop (index + 1) inline_list)
 
-let split_by_macro_or_block_ref inline_list macro_or_block_ref =
-  match macro_or_block_ref with
-  | `Macro macro -> split_by_macro inline_list macro
-  | `Block_ref s -> split_by_block_ref inline_list s
-
 let insert_right z ~expanded_macro =
   match expanded_macro with
   | Z.Branch items -> Z.insert_rights z ~items |? z

--- a/lib/syntax/tree_type.mli
+++ b/lib/syntax/tree_type.mli
@@ -1,0 +1,15 @@
+type t
+
+type value = Type.t_with_pos_meta Zip.l
+
+val of_blocks : Type.blocks -> t
+
+val of_blocks_without_pos : Type.t list -> t
+
+val to_value : t -> value
+
+val replace_embed_and_refs : t -> Reference.parsed_t -> t
+
+val to_blocks : t -> Type.blocks
+
+val to_blocks_without_pos : t -> Type.t list

--- a/lib/syntax/tree_type.mli
+++ b/lib/syntax/tree_type.mli
@@ -8,7 +8,7 @@ val of_blocks_without_pos : Type.t list -> t
 
 val to_value : t -> value
 
-val replace_embed_and_refs : t -> Reference.parsed_t -> t
+val replace_embed_and_refs : t -> refs:Reference.parsed_t -> t
 
 val to_blocks : t -> Type.blocks
 

--- a/lib/syntax/type.ml
+++ b/lib/syntax/type.ml
@@ -109,3 +109,5 @@ and blocks = t_with_pos_meta list [@@deriving yojson]
 
 let pp fmt t =
   Format.pp_print_string fmt @@ Yojson.Safe.pretty_to_string @@ to_yojson t
+
+let dummy_pos = { start_pos = 0; end_pos = 0 }

--- a/lib/zip.ml
+++ b/lib/zip.ml
@@ -1,275 +1,367 @@
 open Prelude
 open Option
 
-type 'a l =
-  | Leaf of 'a
-  | Branch of 'a l list
+module type S = sig
+  type 'a t
 
-type 'a ppath =
-  { left : 'a l list
-  ; right : 'a l list
-  ; pnodes : 'a l list
-  ; ppath : 'a ppath option
-  ; changed : bool
-  }
+  type 'a l =
+    | Leaf of 'a
+    | Branch of 'a l list
 
-type 'a t =
-  { value : 'a l
-  ; ppath : 'a ppath option
-  ; left : 'a l list
-  ; right : 'a l list
-  ; pnodes : 'a l list
-  ; changed : bool
-  ; end' : bool
-  }
+  val leaf : 'a -> 'a l
 
-(* internal helpers *)
+  val branch : 'a l list -> 'a l
 
-let leaf a = Leaf a
+  val of_l : 'a l -> 'a t
 
-let branch a = Branch a
+  val of_list : 'a list -> 'a t
 
-let bool_to_option = function
-  | true -> Some ()
-  | false -> None
+  val node : 'a t -> 'a l
 
-let list_to_option l =
-  match l with
-  | [] -> None
-  | h :: t -> Some (h, t)
+  val is_branch : 'a t -> bool
 
-let butlast l =
-  match List.rev l with
-  | [] -> (None, [])
-  | [ h ] -> (Some h, [])
-  | h :: t -> (Some h, List.rev t)
+  val children : 'a t -> 'a l list option
 
-let rec concat_rev l_rev r =
-  match l_rev with
-  | [] -> r
-  | h :: t -> concat_rev t (h :: r)
+  val children_exn : 'a t -> 'a l list
 
-(* APIs *)
+  val path : 'a t -> 'a l list
 
-let of_l (value : 'a l) =
-  { value
-  ; ppath = None
-  ; left = []
-  ; right = []
-  ; pnodes = []
-  ; changed = false
-  ; end' = false
-  }
+  val lefts : 'a t -> 'a l list
 
-let of_list l =
-  let value = branch @@ CCList.map (fun e -> leaf e) l in
-  of_l value
+  val rights : 'a t -> 'a l list
 
-let node t = t.value
+  val down : 'a t -> 'a t option
 
-let is_branch t =
-  match node t with
-  | Branch _ -> true
-  | Leaf _ -> false
+  val up : 'a t -> 'a t option
 
-let children t =
-  if is_branch t then
-    match node t with
-    | Branch l -> Some l
-    | Leaf _ -> failwith "unreachable"
-  else
-    None
+  val root : 'a t -> 'a l
 
-let children_exn t =
-  match children t with
-  | Some v -> v
-  | None -> failwith "called children on a leaf node"
+  val right : 'a t -> 'a t option
 
-let path t = t.pnodes
+  val rightmost : 'a t -> 'a t
 
-let lefts t = t.left
+  val left : 'a t -> 'a t option
 
-let rights t = t.right
+  val leftmost : 'a t -> 'a t
 
-let down t =
-  bool_to_option (not t.end') >>= fun () ->
-  bool_to_option (is_branch t) >>= fun () ->
-  let node = node t in
-  let cs = get (children t) in
-  match cs with
-  | c :: cnext ->
-    let value = c in
-    let left = [] in
-    let right = cnext in
-    let pnodes = node :: t.pnodes in
-    let ppath' =
-      { left = t.left
-      ; right = t.right
-      ; pnodes = t.pnodes
-      ; changed = t.changed
-      ; ppath = t.ppath
-      }
-    in
-    Some
-      { value
-      ; left
-      ; right
-      ; pnodes
-      ; changed = false
-      ; ppath = Some ppath'
-      ; end' = false
-      }
-  | [] -> None
+  val insert_left : 'a t -> item:'a l -> 'a t option
 
-let up t =
-  bool_to_option (not t.end') >>= fun () ->
-  list_to_option t.pnodes >>= fun (hnode, _) ->
-  let left = map_default (fun (ppath : 'a ppath) -> ppath.left) [] t.ppath in
-  let right = map_default (fun (ppath : 'a ppath) -> ppath.right) [] t.ppath in
-  let pnodes =
-    map_default (fun (ppath : 'a ppath) -> ppath.pnodes) [] t.ppath
-  in
-  let ppath =
-    map_default (fun (ppath : 'a ppath) -> ppath.ppath) None t.ppath
-  in
-  if t.changed then
-    let value = branch @@ List.concat [ List.rev t.left; t.value :: t.right ] in
-    let changed = t.changed in
-    Some { value; left; right; pnodes; changed; ppath; end' = false }
-  else
-    let value = hnode in
-    let changed =
-      map_default (fun (ppath : 'a ppath) -> ppath.changed) false t.ppath
-    in
-    Some { value; left; right; pnodes; changed; ppath; end' = false }
+  val insert_right : 'a t -> item:'a l -> 'a t option
 
-let rec root t =
-  if t.end' then
-    node t
-  else
-    match up t with
-    | Some up_t -> root up_t
-    | None -> node t
+  val insert_lefts : 'a t -> items:'a l list -> 'a t option
 
-let right t =
-  bool_to_option (not t.end') >>= fun () ->
-  list_to_option t.right >>= fun (r, rs) ->
-  let left = t.value :: t.left in
-  let value = r in
-  let right = rs in
-  Some { t with value; left; right }
+  val insert_rights : 'a t -> items:'a l list -> 'a t option
 
-(** Returns the loc of the rightmost sibling of the node at this loc, or self *)
-let rightmost t =
-  let last, butlast = butlast t.right in
-  match last with
-  | None -> t
-  | Some last' ->
-    let value = last' in
-    let left = concat_rev butlast (t.value :: t.left) in
-    let right = [] in
-    { t with value; left; right }
+  val replace : 'a t -> item:'a l -> 'a t
 
-let left t =
-  bool_to_option (not t.end') >>= fun () ->
-  list_to_option t.left >>= fun (l, ls) ->
-  let left = ls in
-  let value = l in
-  let right = t.value :: t.right in
-  Some { t with value; left; right }
+  val edit : 'a t -> f:('a l -> 'a l) -> 'a t
 
-(** Returns the loc of the leftmost sibling of the node at this loc, or self *)
-let leftmost t =
-  let last, butlast = butlast t.left in
-  match last with
-  | None -> t
-  | Some last' ->
-    let value = last' in
-    let left = [] in
-    let right = concat_rev butlast (t.value :: t.right) in
-    { t with value; left; right }
+  val insert_child : 'a t -> item:'a l -> 'a t option
 
-let insert_left t ~item =
-  bool_to_option (not t.end') >>= fun () ->
-  list_to_option t.pnodes >>= fun _ ->
-  let left = item :: t.left in
-  Some { t with left; changed = true }
+  val append_child : 'a t -> item:'a l -> 'a t option
 
-let insert_right t ~item =
-  bool_to_option (not t.end') >>= fun () ->
-  list_to_option t.pnodes >>= fun _ ->
-  let right = item :: t.right in
-  Some { t with right; changed = true }
+  val next : 'a t -> 'a t
 
-let replace t ~item = { t with value = item; changed = true }
+  val prev : 'a t -> 'a t option
 
-let edit t ~f = replace t ~item:(f (node t))
+  val is_end : 'a t -> bool
 
-(** Inserts the item as the leftmost child of the node at this loc, without moving  *)
-let insert_child t ~item =
-  children t >>= fun children ->
-  some @@ replace t ~item:(branch (item :: children))
+  val remove : 'a t -> 'a t option
+end
 
-(** Inserts the item as the rightmost child of the node at this loc, without moving *)
-let append_child t ~item =
-  children t >>= fun children ->
-  some @@ replace t ~item:(branch (List.append children [ item ]))
+module Zipper : S = struct
+  type 'a l =
+    | Leaf of 'a
+    | Branch of 'a l list
 
-let rec next_up_aux t =
-  match up t with
-  | Some t' -> (
-    match right t' with
-    | Some t'' -> t''
-    | None -> next_up_aux t')
-  | None ->
-    { value = node t
+  type 'a ppath =
+    { left : 'a l list
+    ; right : 'a l list
+    ; pnodes : 'a l list
+    ; ppath : 'a ppath option
+    ; changed : bool
+    }
+
+  type 'a t =
+    { value : 'a l
+    ; ppath : 'a ppath option
+    ; left : 'a l list
+    ; right : 'a l list
+    ; pnodes : 'a l list
+    ; changed : bool
+    ; end' : bool
+    }
+
+  (* internal helpers *)
+
+  let leaf a = Leaf a
+
+  let branch a = Branch a
+
+  let bool_to_option = function
+    | true -> Some ()
+    | false -> None
+
+  let list_to_option l =
+    match l with
+    | [] -> None
+    | h :: t -> Some (h, t)
+
+  let butlast l =
+    match List.rev l with
+    | [] -> (None, [])
+    | [ h ] -> (Some h, [])
+    | h :: t -> (Some h, List.rev t)
+
+  let rec concat_rev l_rev r =
+    match l_rev with
+    | [] -> r
+    | h :: t -> concat_rev t (h :: r)
+
+  (* APIs *)
+
+  let of_l (value : 'a l) =
+    { value
     ; ppath = None
     ; left = []
     ; right = []
     ; pnodes = []
     ; changed = false
-    ; end' = true
+    ; end' = false
     }
 
-let next t =
-  if t.end' then
-    t
-  else
-    match down t with
-    | Some t' -> t'
-    | None -> (
-      match right t with
-      | Some t' -> t'
-      | None -> next_up_aux t)
+  let of_list l =
+    let value = branch @@ CCList.map (fun e -> leaf e) l in
+    of_l value
 
-let rec prev_aux t =
-  match down t with
-  | Some t' -> prev_aux (rightmost t')
-  | None -> t
+  let node t = t.value
 
-let prev t =
-  match left t with
-  | Some t' -> some @@ prev_aux t'
-  | None -> up t
+  let is_branch t =
+    match node t with
+    | Branch _ -> true
+    | Leaf _ -> false
 
-let is_end t = t.end'
+  let children t =
+    if is_branch t then
+      match node t with
+      | Branch l -> Some l
+      | Leaf _ -> failwith "unreachable"
+    else
+      None
 
-(** Removes the node at loc, returning the loc that would have preceded it in a depth-first walk. *)
-let remove t =
-  (* not at top level *)
-  list_to_option t.pnodes >>= fun _ ->
-  t.ppath >>= fun ppath ->
-  match t.left with
-  | l :: ls ->
+  let children_exn t =
+    match children t with
+    | Some v -> v
+    | None -> failwith "called children on a leaf node"
+
+  let path t = t.pnodes
+
+  let lefts t = t.left
+
+  let rights t = t.right
+
+  let down t =
+    bool_to_option (not t.end') >>= fun () ->
+    bool_to_option (is_branch t) >>= fun () ->
+    let node = node t in
+    let cs = get (children t) in
+    match cs with
+    | c :: cnext ->
+      let value = c in
+      let left = [] in
+      let right = cnext in
+      let pnodes = node :: t.pnodes in
+      let ppath' =
+        { left = t.left
+        ; right = t.right
+        ; pnodes = t.pnodes
+        ; changed = t.changed
+        ; ppath = t.ppath
+        }
+      in
+      Some
+        { value
+        ; left
+        ; right
+        ; pnodes
+        ; changed = false
+        ; ppath = Some ppath'
+        ; end' = false
+        }
+    | [] -> None
+
+  let up t =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.pnodes >>= fun (hnode, _) ->
+    let left = map_default (fun (ppath : 'a ppath) -> ppath.left) [] t.ppath in
+    let right =
+      map_default (fun (ppath : 'a ppath) -> ppath.right) [] t.ppath
+    in
+    let pnodes =
+      map_default (fun (ppath : 'a ppath) -> ppath.pnodes) [] t.ppath
+    in
+    let ppath =
+      map_default (fun (ppath : 'a ppath) -> ppath.ppath) None t.ppath
+    in
+    if t.changed then
+      let value =
+        branch @@ List.concat [ List.rev t.left; t.value :: t.right ]
+      in
+      let changed = t.changed in
+      Some { value; left; right; pnodes; changed; ppath; end' = false }
+    else
+      let value = hnode in
+      let changed =
+        map_default (fun (ppath : 'a ppath) -> ppath.changed) false t.ppath
+      in
+      Some { value; left; right; pnodes; changed; ppath; end' = false }
+
+  let rec root t =
+    if t.end' then
+      node t
+    else
+      match up t with
+      | Some up_t -> root up_t
+      | None -> node t
+
+  let right t =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.right >>= fun (r, rs) ->
+    let left = t.value :: t.left in
+    let value = r in
+    let right = rs in
+    Some { t with value; left; right }
+
+  (** Returns the loc of the rightmost sibling of the node at this loc, or self *)
+  let rightmost t =
+    let last, butlast = butlast t.right in
+    match last with
+    | None -> t
+    | Some last' ->
+      let value = last' in
+      let left = concat_rev butlast (t.value :: t.left) in
+      let right = [] in
+      { t with value; left; right }
+
+  let left t =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.left >>= fun (l, ls) ->
     let left = ls in
     let value = l in
-    let changed = true in
-    some @@ prev_aux { t with left; value; changed }
-  | [] ->
-    let value = branch t.right in
-    let changed = true in
-    let left = ppath.left in
-    let right = ppath.right in
-    let ppath' = ppath.ppath in
-    let pnodes = ppath.pnodes in
-    some @@ { t with value; left; right; changed; pnodes; ppath = ppath' }
+    let right = t.value :: t.right in
+    Some { t with value; left; right }
+
+  (** Returns the loc of the leftmost sibling of the node at this loc, or self *)
+  let leftmost t =
+    let last, butlast = butlast t.left in
+    match last with
+    | None -> t
+    | Some last' ->
+      let value = last' in
+      let left = [] in
+      let right = concat_rev butlast (t.value :: t.right) in
+      { t with value; left; right }
+
+  let insert_left t ~item =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.pnodes >>= fun _ ->
+    let left = item :: t.left in
+    Some { t with left; changed = true }
+
+  let insert_right t ~item =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.pnodes >>= fun _ ->
+    let right = item :: t.right in
+    Some { t with right; changed = true }
+
+  (** insert_lefts t [a;b;c] ->
+    [t.lefts;c;b;a,<current-location>;t.rights] *)
+  let insert_lefts t ~items =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.pnodes >>= fun _ ->
+    let left = items @ t.left in
+    Some { t with left; changed = true }
+
+  (* insert_rights t [a;b;c] ->
+     [t.lefts;<current-location>;a;b;c;t.rights] *)
+  let insert_rights t ~items =
+    bool_to_option (not t.end') >>= fun () ->
+    list_to_option t.pnodes >>= fun _ ->
+    let right = items @ t.right in
+    Some { t with right; changed = true }
+
+  let replace t ~item = { t with value = item; changed = true }
+
+  let edit t ~f = replace t ~item:(f (node t))
+
+  (** Inserts the item as the leftmost child of the node at this loc, without moving  *)
+  let insert_child t ~item =
+    children t >>= fun children ->
+    some @@ replace t ~item:(branch (item :: children))
+
+  (** Inserts the item as the rightmost child of the node at this loc, without moving *)
+  let append_child t ~item =
+    children t >>= fun children ->
+    some @@ replace t ~item:(branch (List.append children [ item ]))
+
+  let rec next_up_aux t =
+    match up t with
+    | Some t' -> (
+      match right t' with
+      | Some t'' -> t''
+      | None -> next_up_aux t')
+    | None ->
+      { value = node t
+      ; ppath = None
+      ; left = []
+      ; right = []
+      ; pnodes = []
+      ; changed = false
+      ; end' = true
+      }
+
+  let next t =
+    if t.end' then
+      t
+    else
+      match down t with
+      | Some t' -> t'
+      | None -> (
+        match right t with
+        | Some t' -> t'
+        | None -> next_up_aux t)
+
+  let rec prev_aux t =
+    match down t with
+    | Some t' -> prev_aux (rightmost t')
+    | None -> t
+
+  let prev t =
+    match left t with
+    | Some t' -> some @@ prev_aux t'
+    | None -> up t
+
+  let is_end t = t.end'
+
+  (** Removes the node at loc, returning the loc that would have preceded it in a depth-first walk. *)
+  let remove t =
+    (* not at top level *)
+    list_to_option t.pnodes >>= fun _ ->
+    t.ppath >>= fun ppath ->
+    match t.left with
+    | l :: ls ->
+      let left = ls in
+      let value = l in
+      let changed = true in
+      some @@ prev_aux { t with left; value; changed }
+    | [] ->
+      let value = branch t.right in
+      let changed = true in
+      let left = ppath.left in
+      let right = ppath.right in
+      let ppath' = ppath.ppath in
+      let pnodes = ppath.pnodes in
+      some @@ { t with value; left; right; changed; pnodes; ppath = ppath' }
+end
+
+include Zipper


### PR DESCRIPTION
- markdown.ml & tree_type.ml
  - [X] move out module Output
  - [X] replace embed&block-ref in tree-type
- zip.ml
  - [X] add insert_lefts&insert_rights
  - [X] add type signature
- opml.ml
  -  [X] replace embed & block-ref in opml