### PR TITLE
feat: support `- ##` like heading

### DIFF
--- a/lib/document.ml
+++ b/lib/document.ml
@@ -113,8 +113,17 @@ let from_ast filename ast =
         let directives = (k, v) :: directives in
         aut directives blocks toc tl
       | Heading
-          { title; tags; marker; level; priority; anchor; meta; unordered; _ }
-        ->
+          { title
+          ; tags
+          ; marker
+          ; level
+          ; priority
+          ; anchor
+          ; meta
+          ; unordered
+          ; size
+          ; _
+          } ->
         let numbering = compute_heading_numbering level toc in
         let h =
           Heading
@@ -127,6 +136,7 @@ let from_ast filename ast =
             ; meta
             ; numbering = Some numbering
             ; unordered
+            ; size
             }
         in
         let toc_item = { title; level; anchor; numbering; items = [] } in

--- a/lib/syntax/type.ml
+++ b/lib/syntax/type.ml
@@ -16,6 +16,7 @@ type heading =
   ; anchor : string
   ; meta : meta
   ; unordered : bool  (** whether it's an unordered list (starts with `-`) **)
+  ; size : int option
   }
 [@@deriving yojson]
 

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -568,6 +568,39 @@ let block =
                    }
                  ]) )
         ] )
+  ; ( "unordered list"
+    , testcases
+        [ ( "with size (1)"
+          , `Quick
+          , check_aux "- ## TODO text"
+              (Type.Heading
+                 { Type.title = [ Inline.Plain "text" ]
+                 ; tags = []
+                 ; marker = Some "TODO"
+                 ; level = 1
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = "text"
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = Some 2
+                 }) )
+        ; ( "with size (2)"
+          , `Quick
+          , check_aux "- ##"
+              (Type.Heading
+                 { Type.title = []
+                 ; tags = []
+                 ; marker = None
+                 ; level = 1
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = ""
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = Some 2
+                 }) )
+        ] )
   ]
 
 let () = Alcotest.run "mldoc" @@ List.concat [ inline; block ]


### PR DESCRIPTION
Added new field `size: int option` to `Heading`.

example: `"- ##"`
-> 
```
Type.Heading
                 { Type.title = []
                 ; tags = []
                 ; marker = None
                 ; level = 1
                 ; numbering = None
                 ; priority = None
                 ; anchor = ""
                 ; meta = { Type.timestamps = []; properties = [] }
                 ; unordered = true
                 ; size = Some 2
                 }
```

