### PR TITLE
[WIP] feat: parsing return inline_type position info

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -21,6 +21,7 @@ let main () =
                ; heading_to_list = false
                ; exporting_keep_properties = false
                ; ignore_heading_list_marker = false
+               ; inline_type_with_pos = false
                }
              in
              ignore (parse config doc_org))
@@ -33,6 +34,7 @@ let main () =
                ; heading_to_list = false
                ; exporting_keep_properties = false
                ; ignore_heading_list_marker = false
+               ; inline_type_with_pos = false
                }
              in
              ignore (parse config syntax_org))
@@ -45,6 +47,7 @@ let main () =
                ; heading_to_list = false
                ; exporting_keep_properties = false
                ; ignore_heading_list_marker = false
+               ; inline_type_with_pos = false
                }
              in
              ignore (parse config syntax_md))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -35,6 +35,7 @@ let generate backend output _opts filename =
       ; heading_to_list = true
       ; exporting_keep_properties = true
       ; ignore_heading_list_marker = false
+      ; inline_type_with_pos = false
       }
     in
     let ast = parse config (String.concat "\n" lines) in

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -4,7 +4,7 @@ open Type
 type toc = toc_item list [@@deriving yojson]
 
 and toc_item =
-  { title : Inline.t list
+  { title : Inline.t_with_pos list
   ; level : int
   ; anchor : string
   ; numbering : int list
@@ -143,7 +143,7 @@ let from_ast filename ast =
         aut directives ((h, pos_meta) :: blocks) (toc_item :: toc) tl
       | Paragraph inlines ->
         let blocks =
-          match get_timestamps inlines with
+          match get_timestamps (Type_op.inline_list_strip_pos inlines) with
           | [] -> (h, pos_meta) :: blocks
           | timestamps ->
             update_meta (fun heading ->

--- a/lib/export/conf.ml
+++ b/lib/export/conf.ml
@@ -24,6 +24,7 @@ type t =
   ; exporting_keep_properties : bool
         [@default false] (* keep properties when exporting *)
   ; ignore_heading_list_marker : bool [@default false]
+  ; inline_type_with_pos : bool [@default false]
   }
 [@@deriving yojson]
 

--- a/lib/export/opml.ml
+++ b/lib/export/opml.ml
@@ -13,6 +13,7 @@ let default_config =
   ; heading_to_list = true
   ; exporting_keep_properties = false
   ; ignore_heading_list_marker = true
+  ; inline_type_with_pos = false
   }
 
 let rec block_tree_to_plain_tree (blocks : Tree_type.value) : string Zip.l =

--- a/lib/syntax/block.ml
+++ b/lib/syntax/block.ml
@@ -1,9 +1,10 @@
+open! Prelude
 open Angstrom
 open Parsers
-open Prelude
 open Type
 open Conf
 open Helper
+open Pos
 
 (* There are 2 kinds of blocks.
    1. `begin ... end`

--- a/lib/syntax/extended/nested_link.ml
+++ b/lib/syntax/extended/nested_link.ml
@@ -8,7 +8,7 @@ open Parsers
 
 type child =
   | Label of string
-  | Nested_link of t
+  | Nested_link of t_with_pos
 
 and children = child list
 
@@ -17,6 +17,26 @@ and t =
   ; children : children
   }
 [@@deriving yojson]
+
+and t_with_pos = t * Pos.pos_meta option
+
+let t_with_pos_to_yojson t_with_pos : Yojson.Safe.t =
+  let t, pos = t_with_pos in
+  let t_yojson = to_yojson t in
+  match pos with
+  | None -> t_yojson
+  | Some pos' ->
+    let pos_yojson = Pos.pos_meta_to_yojson pos' in
+    `List [ t_yojson; pos_yojson ]
+
+let t_with_pos_of_yojson (json : Yojson.Safe.t) =
+  let open Ppx_deriving_yojson_runtime in
+  match json with
+  | `List [ t; pos ] ->
+    of_yojson t >>= fun t' ->
+    Pos.pos_meta_of_yojson pos >|= fun pos' -> (t', Some pos')
+  | `Assoc _ as t -> of_yojson t >|= fun t' -> (t', None)
+  | _ -> Result.Error "invalid_arg: Nested_link.t_with_pos_of_yojson"
 
 let open_brackets = "[["
 
@@ -42,21 +62,36 @@ let match_brackets () =
 
 let label_parse = take_while1 (fun c -> c <> '[') >>| fun s -> Label s
 
-let parse =
+let parse (config : Conf.t) =
+  let open Pos in
+  let prefix_pos = Stack.create () in
+  Stack.push 0 prefix_pos;
   fix (fun p ->
       let children_parse = many1 (choice [ label_parse; p ]) in
+      pos >>= fun start_pos ->
+      let start_pos = start_pos + Stack.top prefix_pos in
       match_brackets () >>= fun s ->
+      pos >>= fun end_pos ->
+      let end_pos = end_pos + Stack.top prefix_pos in
+      Stack.push (start_pos + 2) prefix_pos;
       let inner_s = String.sub s 2 (String.length s - 4) in
       let result =
         match parse_string ~consume:All children_parse inner_s with
         | Ok result -> result
         | Error _e -> [ Label inner_s ]
       in
-      return @@ Nested_link { content = s; children = result })
+      let _ = Stack.pop prefix_pos in
+      let pos =
+        if config.inline_type_with_pos then
+          Some { start_pos; end_pos }
+        else
+          None
+      in
+      return @@ Nested_link ({ content = s; children = result }, pos))
   >>= function
   | Label _l -> fail "nested link"
-  | Nested_link { content; children } ->
+  | Nested_link ({ content; children }, pos) ->
     if List.length children <= 1 then
       fail "nested link"
     else
-      return @@ { content; children }
+      return @@ ({ content; children }, pos)

--- a/lib/syntax/footnote.ml
+++ b/lib/syntax/footnote.ml
@@ -1,3 +1,4 @@
+open! Prelude
 open Angstrom
 open Parsers
 open Type
@@ -61,7 +62,7 @@ let definition_parse config =
         match
           parse_string ~consume:All (Inline.parse config) definition_content
         with
-        | Ok inlines -> inlines
+        | Ok inlines -> List.map fst inlines
         | Error _e -> [ Inline.Plain definition_content ]
       in
       Footnote_Definition (name, definition))

--- a/lib/syntax/helper.ml
+++ b/lib/syntax/helper.ml
@@ -1,6 +1,6 @@
-open Angstrom
-open Type
 open! Prelude
+open Angstrom
+open Pos
 
 let with_pos_meta p =
   lift3 (fun start_pos t end_pos -> (t, { start_pos; end_pos })) pos p pos

--- a/lib/syntax/lists.ml
+++ b/lib/syntax/lists.ml
@@ -137,7 +137,7 @@ let definition config s =
       let name =
         match parse_string ~consume:All (Inline.parse config) name with
         | Ok inlines -> inlines
-        | Error _e -> [ Inline.Plain name ]
+        | Error _e -> Type_op.inline_list_with_none_pos [ Inline.Plain name ]
       in
       (name, description)
     | None -> ([], description))
@@ -175,7 +175,10 @@ let rec list_parser config content_parsers items last_indent =
             | Ok result ->
               let result = Paragraph.concat_paragraph_lines config result in
               List.map fst result
-            | Error _e -> [ Paragraph [ Inline.Plain content ] ]
+            | Error _e ->
+              [ Paragraph
+                  (Type_op.inline_list_with_none_pos [ Inline.Plain content ])
+              ]
           in
           let item =
             { content

--- a/lib/syntax/markdown_definition.ml
+++ b/lib/syntax/markdown_definition.ml
@@ -39,7 +39,7 @@ let definition_parse config =
   let name =
     match parse_string ~consume:All (Inline.parse config) name with
     | Ok inlines -> inlines
-    | Error _e -> [ Inline.Plain name ]
+    | Error _e -> Type_op.inline_list_with_none_pos [ Inline.Plain name ]
   in
   let content =
     List.map
@@ -48,7 +48,8 @@ let definition_parse config =
           parse_string ~consume:All (Inline.parse config) (String.trim line)
         with
         | Ok content -> Paragraph content
-        | Error _e -> Paragraph [ Inline.Plain line ])
+        | Error _e ->
+          Paragraph (Type_op.inline_list_with_none_pos [ Inline.Plain line ]))
       lines
   in
   let list =

--- a/lib/syntax/paragraph.ml
+++ b/lib/syntax/paragraph.ml
@@ -1,7 +1,8 @@
+open! Prelude
 open Angstrom
 open Parsers
 open Type
-open! Prelude
+open Pos
 
 (* inline and footnotes *)
 
@@ -22,7 +23,8 @@ let parse_lines config lines pos1 pos2 =
   let paragraph =
     match parse_string ~consume:All (Inline.parse config) content with
     | Ok result -> Paragraph result
-    | Error _ -> Paragraph [ Inline.Plain content ]
+    | Error _ ->
+      Paragraph (Type_op.inline_list_with_none_pos [ Inline.Plain content ])
   in
   (paragraph, { start_pos = pos1; end_pos = pos2 })
 

--- a/lib/syntax/pos.ml
+++ b/lib/syntax/pos.ml
@@ -1,0 +1,7 @@
+type pos_meta =
+  { start_pos : int
+  ; end_pos : int
+  }
+[@@deriving yojson]
+
+let dummy_pos = { start_pos = 0; end_pos = 0 }

--- a/lib/syntax/table.ml
+++ b/lib/syntax/table.ml
@@ -61,7 +61,8 @@ let group config =
             List.map
               (fun col ->
                 result_default [ Inline.Plain col ]
-                  (parse_string ~consume:All (Inline.parse config) col))
+                  (Result.map (List.map fst)
+                     (parse_string ~consume:All (Inline.parse config) col)))
               row
           in
           rows := row :: !rows;

--- a/lib/syntax/type.ml
+++ b/lib/syntax/type.ml
@@ -1,10 +1,4 @@
-type inline_list = Inline.t list [@@deriving yojson]
-
-type pos_meta =
-  { start_pos : int
-  ; end_pos : int
-  }
-[@@deriving yojson]
+type inline_list = Inline.t_with_pos list [@@deriving yojson]
 
 type heading =
   { title : inline_list  (** The title as inline formatted content *)
@@ -30,7 +24,7 @@ and list_item =
   { content : t list  (** The contents of the current item *)
   ; items : list_item list
   ; number : int option [@default None]  (** Its number *)
-  ; name : Inline.t list  (** Definition name *)
+  ; name : Inline.t_with_pos list  (** Definition name *)
   ; checkbox : bool option [@default None]  (** Was it checked *)
   ; indent : int  (** Indentation of the current item. *)
   ; ordered : bool
@@ -56,13 +50,14 @@ and code_block =
   ; language : string option [@default None]
         (** The language the code is written in *)
   ; options : string list option [@default None]
-  ; pos_meta : pos_meta
+  ; pos_meta : Pos.pos_meta
   }
 [@@deriving yojson]
 (** Code blocks *)
 
 and t =
-  | Paragraph of Inline.t list  (** A paragraph containing only inline text *)
+  | Paragraph of Inline.t_with_pos list
+      (** A paragraph containing only inline text *)
   | Paragraph_line of string  (** Internal usage *)
   | Paragraph_Sep of int
   | Heading of heading  (** A heading *)
@@ -102,7 +97,7 @@ and t =
   | Hiccup of string
 [@@deriving yojson]
 
-and t_with_pos_meta = t * pos_meta [@@deriving yojson]
+and t_with_pos_meta = t * Pos.pos_meta [@@deriving yojson]
 
 and t_with_content = t * string [@@deriving yojson]
 
@@ -114,5 +109,3 @@ and blocks_with_content = t_with_content list [@@deriving yojson]
 
 let pp fmt t =
   Format.pp_print_string fmt @@ Yojson.Safe.pretty_to_string @@ to_yojson t
-
-let dummy_pos = { start_pos = 0; end_pos = 0 }

--- a/lib/syntax/type_op.ml
+++ b/lib/syntax/type_op.ml
@@ -1,6 +1,32 @@
 open! Prelude
+open Pos
 
 let remove_properties =
   List.filter (function
     | Type.Property_Drawer _ -> false
     | _ -> true)
+
+let inline_list_with_dummy_pos (l : 'a list) : ('a * pos_meta option) list =
+  List.map (fun i -> (i, Some Pos.dummy_pos)) l
+
+let inline_list_with_none_pos (l : 'a list) : ('a * pos_meta option) list =
+  List.map (fun i -> (i, None)) l
+
+let inline_list_strip_pos (l : ('a * pos_meta option) list) : 'a list =
+  List.map fst l
+
+let inline_with_pos i start_pos end_pos =
+  (i, Some ({ start_pos; end_pos } : Pos.pos_meta))
+
+let inline_list_move_forward l forward_pos =
+  List.map
+    (fun (i, pos) ->
+      ( i
+      , match pos with
+        | None -> None
+        | Some { start_pos; end_pos } ->
+          Some
+            { start_pos = start_pos + forward_pos
+            ; end_pos = end_pos + forward_pos
+            } ))
+    l

--- a/lib/transform/markdown_transformer.ml
+++ b/lib/transform/markdown_transformer.ml
@@ -18,6 +18,7 @@ end = struct
     ; heading_to_list = false
     ; exporting_keep_properties = false
     ; ignore_heading_list_marker = false
+    ; inline_type_with_pos = false
     }
 
   let rec of_value v ~config =
@@ -55,7 +56,7 @@ end = struct
                 let ast = Mldoc_parser.parse default_config e in
                 let ast' =
                   List.map
-                    (fun (ast, (pos : Type.pos_meta)) ->
+                    (fun (ast, (pos : Pos.pos_meta)) ->
                       ( ast
                       , String.sub e pos.start_pos (pos.end_pos - pos.start_pos)
                       ))
@@ -85,7 +86,7 @@ end = struct
         let head_ast' = (head', head_content) in
         let body_ast' =
           List.map
-            (fun (ast, (pos : Type.pos_meta)) ->
+            (fun (ast, (pos : Pos.pos_meta)) ->
               (ast, String.sub h pos.start_pos (pos.end_pos - pos.start_pos)))
             body_ast'
         in

--- a/test/test_export_markdown.ml
+++ b/test/test_export_markdown.ml
@@ -6,13 +6,16 @@ let default_config : Conf.t =
   ; heading_to_list = false
   ; exporting_keep_properties = false
   ; ignore_heading_list_marker = false
+  ; inline_type_with_pos = false
   }
 
 let refs : Reference.parsed_t =
   { parsed_embed_blocks =
       [ ( "ref1"
         , ( [ Type.Heading
-                { Type.title = [ Inline.Plain "ref1-text" ]
+                { Type.title =
+                    Type_op.inline_list_with_none_pos
+                      [ Inline.Plain "ref1-text" ]
                 ; tags = []
                 ; marker = None
                 ; level = 1
@@ -27,7 +30,9 @@ let refs : Reference.parsed_t =
                 [ ("id", "60d2ead8-23c1-4617-b2df-4ef0dcfbbf2e") ]
             ]
           , [ Type.Heading
-                { Type.title = [ Inline.Plain "ref1-text" ]
+                { Type.title =
+                    Type_op.inline_list_with_none_pos
+                      [ Inline.Plain "ref1-text" ]
                 ; tags = []
                 ; marker = None
                 ; level = 1

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -6,6 +6,7 @@ let default_config : Conf.t =
   ; heading_to_list = false
   ; exporting_keep_properties = false
   ; ignore_heading_list_marker = false
+  ; inline_type_with_pos = false
   }
 
 let check_mldoc_type =
@@ -18,6 +19,8 @@ let check_aux source expect =
 let testcases =
   List.map (fun (case, level, f) -> Alcotest.test_case case level f)
 
+let paragraph l = Type.Paragraph (Type_op.inline_list_with_none_pos l)
+
 let inline =
   let open Type in
   let module I = Inline in
@@ -26,7 +29,7 @@ let inline =
         [ ( "normal"
           , `Quick
           , check_aux "http://testtest/asdasd"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -40,7 +43,7 @@ let inline =
         ; ( "normal-2"
           , `Quick
           , check_aux "[test  normal](http://testtest/asdasd)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -54,7 +57,7 @@ let inline =
         ; ( "inline-code-in-label"
           , `Quick
           , check_aux "[test `normal`](http://testtest/asdasd)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -68,7 +71,7 @@ let inline =
         ; ( "with-*"
           , `Quick
           , check_aux "http://testtest/asd*asd"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -82,7 +85,7 @@ let inline =
         ; ( "spaces-around-link-line"
           , `Quick
           , check_aux " http://testtest/asdasd "
-              (Paragraph
+              (paragraph
                  [ I.Plain " "
                  ; I.Link
                      { url =
@@ -98,7 +101,7 @@ let inline =
         ; ( "endwith '.'"
           , `Quick
           , check_aux "http://test/f.o.o/b.a.r. "
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -113,7 +116,7 @@ let inline =
         ; ( "include brackets"
           , `Quick
           , check_aux "http://test/(foo)bar"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -127,7 +130,7 @@ let inline =
         ; ( "include brackets (2)"
           , `Quick
           , check_aux "http://test/[(foo)b]ar"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -141,7 +144,7 @@ let inline =
         ; ( "include brackets (3)"
           , `Quick
           , check_aux "http://test/[foo)b]ar"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex { protocol = "http"; link = "//test/[foo" }
@@ -155,7 +158,7 @@ let inline =
         ; ( "include brackets (4)"
           , `Quick
           , check_aux "http://te(s)t/foobar"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Complex { protocol = "http"; link = "//te" }
                      ; label = [ Plain "http://te" ]
@@ -171,7 +174,7 @@ let inline =
         [ ( "normal"
           , `Quick
           , check_aux "[label here](http://foobar/path?query=123)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -187,7 +190,7 @@ let inline =
         ; ( "also support org-link syntax"
           , `Quick
           , check_aux "[[http://foobar/path?query=123][label here]]"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -203,7 +206,7 @@ let inline =
         ; ( "label with page-ref"
           , `Quick
           , check_aux "[abc [[d ef]] gh](../assets/0000.pdf)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "../assets/0000.pdf"
                      ; label = [ Plain "abc [[d ef]] gh" ]
@@ -215,7 +218,7 @@ let inline =
         ; ( "with title"
           , `Quick
           , check_aux "[abc [[d]( ef]] gh](../assets/0000.pdf \"title\")"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "../assets/0000.pdf"
                      ; label = [ Plain "abc [[d]( ef]] gh" ]
@@ -228,7 +231,7 @@ let inline =
         ; ( "include brackets"
           , `Quick
           , check_aux "[label](abc(def)gh)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "abc(def)gh"
                      ; label = [ Plain "label" ]
@@ -240,7 +243,7 @@ let inline =
         ; ( "include brackets (2)"
           , `Quick
           , check_aux "[中文](https://a.b.c.d/e/f%20g(1).h)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url =
                          I.Complex
@@ -256,7 +259,7 @@ let inline =
         ; ( "page-ref before link"
           , `Quick
           , check_aux "[[a]][b](c)"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "a"
                      ; label = [ Plain "" ]
@@ -275,7 +278,7 @@ let inline =
         ; ( "url and title"
           , `Quick
           , check_aux "[a](bbb[[ccc \"dd\"]] \"e f\")"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "bbb[[ccc \"dd\"]]"
                      ; label = [ Plain "a" ]
@@ -287,7 +290,7 @@ let inline =
         ; ( "url part include page ref"
           , `Quick
           , check_aux "[a](bbb[[ccc \"dd\"]][[ff gg hh]] \"ee\")"
-              (Paragraph
+              (paragraph
                  [ I.Link
                      { url = I.Search "bbb[[ccc \"dd\"]][[ff gg hh]]"
                      ; label = [ Plain "a" ]
@@ -302,19 +305,19 @@ let inline =
         [ ( "double"
           , `Quick
           , check_aux "{{test foo}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro { I.Macro.name = "test"; arguments = [ "foo" ] } ])
           )
         ; ( "three"
           , `Quick
           , check_aux "{{{test foo}}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro { I.Macro.name = "test"; arguments = [ "foo" ] } ])
           )
         ; ( "query"
           , `Quick
           , check_aux "{{query (and [[test]])}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro
                      { I.Macro.name = "query"
                      ; arguments = [ "(and [[test]])" ]
@@ -323,14 +326,14 @@ let inline =
         ; ( "embed"
           , `Quick
           , check_aux "{{{embed [[page]]}}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro
                      { I.Macro.name = "embed"; arguments = [ "[[page]]" ] }
                  ]) )
         ; ( "query nested link"
           , `Quick
           , check_aux "{{{query [[page [[nested]]]]}}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro
                      { I.Macro.name = "query"
                      ; arguments = [ "[[page [[nested]]]]" ]
@@ -339,7 +342,7 @@ let inline =
         ; ( "args"
           , `Quick
           , check_aux "{{macroname [[A,B]], ((C,D)), E}}"
-              (Paragraph
+              (paragraph
                  [ I.Macro
                      { I.Macro.name = "macroname"
                      ; arguments = [ "[[A,B]]"; "((C,D))"; "E" ]
@@ -390,26 +393,26 @@ let inline =
     , testcases
         [ ( "normal"
           , `Quick
-          , check_aux "`codes here`" (Paragraph [ I.Code "codes here" ]) )
+          , check_aux "`codes here`" (paragraph [ I.Code "codes here" ]) )
         ; ( "overlap-with-emphasis"
           , `Quick
-          , check_aux "*aa`*`" (Paragraph [ I.Plain "*aa"; I.Code "*" ]) )
+          , check_aux "*aa`*`" (paragraph [ I.Plain "*aa"; I.Code "*" ]) )
         ; ( "overlap-with-emphasis-2"
           , `Quick
-          , check_aux "**aa`**`" (Paragraph [ I.Plain "**aa"; I.Code "**" ]) )
+          , check_aux "**aa`**`" (paragraph [ I.Plain "**aa"; I.Code "**" ]) )
         ; ( "overlap-with-emphasis-3"
           , `Quick
-          , check_aux "_a`_`" (Paragraph [ I.Plain "_a"; I.Code "_" ]) )
+          , check_aux "_a`_`" (paragraph [ I.Plain "_a"; I.Code "_" ]) )
         ; ( "overlap-with-emphasis-4"
           , `Quick
-          , check_aux "__a`__`" (Paragraph [ I.Plain "__a"; I.Code "__" ]) )
+          , check_aux "__a`__`" (paragraph [ I.Plain "__a"; I.Code "__" ]) )
         ; ( "overlap-with-emphasis-5"
           , `Quick
-          , check_aux "`as*d`*" (Paragraph [ I.Code "as*d"; I.Plain "*" ]) )
+          , check_aux "`as*d`*" (paragraph [ I.Code "as*d"; I.Plain "*" ]) )
         ; ( "overlap-with-link"
           , `Quick
           , check_aux "[as`d](`http://dwdw)"
-              (Paragraph
+              (paragraph
                  [ I.Plain "[as"
                  ; I.Code "d]("
                  ; I.Link
@@ -424,32 +427,32 @@ let inline =
         ; ( "overlap-with-link-2"
           , `Quick
           , check_aux "[as`d](http://dwdw)`"
-              (Paragraph [ I.Plain "[as"; I.Code "d](http://dwdw)" ]) )
+              (paragraph [ I.Plain "[as"; I.Code "d](http://dwdw)" ]) )
         ] )
   ; ( "emphasis"
     , testcases
         [ ( "normal"
           , `Quick
           , check_aux "*abc*"
-              (Paragraph [ I.Emphasis (`Italic, [ Plain "abc" ]) ]) )
+              (paragraph [ I.Emphasis (`Italic, [ Plain "abc" ]) ]) )
         ; ( "normal-2"
           , `Quick
           , check_aux "**abc**"
-              (Paragraph [ I.Emphasis (`Bold, [ Plain "abc" ]) ]) )
+              (paragraph [ I.Emphasis (`Bold, [ Plain "abc" ]) ]) )
         ; ( "normal-3"
           , `Quick
           , check_aux "_a_,"
-              (Paragraph [ I.Emphasis (`Italic, [ Plain "a" ]); I.Plain "," ])
+              (paragraph [ I.Emphasis (`Italic, [ Plain "a" ]); I.Plain "," ])
           )
         ; ( "inline-code-inside"
           , `Quick
           , check_aux "*asd`qwe`*"
-              (Paragraph
+              (paragraph
                  [ I.Emphasis (`Italic, [ I.Plain "asd"; I.Code "qwe" ]) ]) )
         ; ( "inline-code-inside-2"
           , `Quick
           , check_aux "***asd`qwe`***"
-              (Paragraph
+              (paragraph
                  [ I.Emphasis
                      ( `Italic
                      , [ I.Emphasis (`Bold, [ I.Plain "asd"; I.Code "qwe" ]) ]
@@ -457,25 +460,25 @@ let inline =
                  ]) )
         ; ( "not emphasis (1)"
           , `Quick
-          , check_aux "a * b*" (Paragraph [ I.Plain "a * b*" ]) )
+          , check_aux "a * b*" (paragraph [ I.Plain "a * b*" ]) )
         ; ( "not emphasis (2)"
           , `Quick
-          , check_aux "a_b_c" (Paragraph [ I.Plain "a_b_c" ]) )
+          , check_aux "a_b_c" (paragraph [ I.Plain "a_b_c" ]) )
         ; ( "contains underline"
           , `Quick
           , check_aux "_a _ a_"
-              (Paragraph [ I.Emphasis (`Italic, [ I.Plain "a _ a" ]) ]) )
+              (paragraph [ I.Emphasis (`Italic, [ I.Plain "a _ a" ]) ]) )
         ; ( "contains star"
           , `Quick
           , check_aux "*a * a*"
-              (Paragraph [ I.Emphasis (`Italic, [ I.Plain "a * a" ]) ]) )
+              (paragraph [ I.Emphasis (`Italic, [ I.Plain "a * a" ]) ]) )
         ; ( "left flanking delimiter"
           , `Quick
-          , check_aux "hello_world_" (Paragraph [ I.Plain "hello_world_" ]) )
+          , check_aux "hello_world_" (paragraph [ I.Plain "hello_world_" ]) )
         ; ( "left flanking delimiter (2)"
           , `Quick
           , check_aux "hello,_world_"
-              (Paragraph
+              (paragraph
                  [ I.Plain "hello,"; I.Emphasis (`Italic, [ I.Plain "world" ]) ])
           )
         ] )
@@ -483,28 +486,28 @@ let inline =
     , testcases
         [ ( "endwith '.'"
           , `Quick
-          , check_aux "#tag." (Paragraph [ I.Tag "tag"; I.Plain "." ]) )
+          , check_aux "#tag." (paragraph [ I.Tag "tag"; I.Plain "." ]) )
         ; ( "endwith ','"
           , `Quick
-          , check_aux "#tag," (Paragraph [ I.Tag "tag"; I.Plain "," ]) )
+          , check_aux "#tag," (paragraph [ I.Tag "tag"; I.Plain "," ]) )
         ; ( "endwith '\"'"
           , `Quick
-          , check_aux "#tag\"" (Paragraph [ I.Tag "tag"; I.Plain "\"" ]) )
+          , check_aux "#tag\"" (paragraph [ I.Tag "tag"; I.Plain "\"" ]) )
         ; ( "endwith several periods"
           , `Quick
-          , check_aux "#tag,.?" (Paragraph [ I.Tag "tag"; I.Plain ",.?" ]) )
-        ; ("with '.'", `Quick, check_aux "#a.b.c" (Paragraph [ I.Tag "a.b.c" ]))
+          , check_aux "#tag,.?" (paragraph [ I.Tag "tag"; I.Plain ",.?" ]) )
+        ; ("with '.'", `Quick, check_aux "#a.b.c" (paragraph [ I.Tag "a.b.c" ]))
         ; ( "with '.' and endwith '.'"
           , `Quick
-          , check_aux "#a.b.c." (Paragraph [ I.Tag "a.b.c"; I.Plain "." ]) )
+          , check_aux "#a.b.c." (paragraph [ I.Tag "a.b.c"; I.Plain "." ]) )
         ; ( "with '.' and endwith '.' (2)"
           , `Quick
           , check_aux "#a.b.c. defg"
-              (Paragraph [ I.Tag "a.b.c"; I.Plain ". defg" ]) )
+              (paragraph [ I.Tag "a.b.c"; I.Plain ". defg" ]) )
         ; ( "with page-ref"
           , `Quick
           , check_aux "#a.[[b c d ]].e."
-              (Paragraph [ I.Tag "a.[[b c d ]].e"; I.Plain "." ]) )
+              (paragraph [ I.Tag "a.[[b c d ]].e"; I.Plain "." ]) )
         ] )
   ]
 
@@ -524,7 +527,7 @@ let block =
           , `Quick
           , check_aux ">foo\n>bar"
               (Quote
-                 [ Paragraph
+                 [ paragraph
                      [ I.Plain "foo"
                      ; I.Break_Line
                      ; I.Plain "bar"
@@ -545,7 +548,7 @@ let block =
           , `Quick
           , check_aux "+ line1\n  - heading"
               (List
-                 [ { content = [ Paragraph [ I.Plain "line1" ] ]
+                 [ { content = [ paragraph [ I.Plain "line1" ] ]
                    ; items = []
                    ; number = None
                    ; name = []
@@ -558,7 +561,7 @@ let block =
           , `Quick
           , check_aux "+ line1\n  -"
               (List
-                 [ { content = [ Paragraph [ I.Plain "line1" ] ]
+                 [ { content = [ paragraph [ I.Plain "line1" ] ]
                    ; items = []
                    ; number = None
                    ; name = []
@@ -574,7 +577,8 @@ let block =
           , `Quick
           , check_aux "- ## TODO text"
               (Type.Heading
-                 { Type.title = [ Inline.Plain "text" ]
+                 { Type.title =
+                     Type_op.inline_list_with_none_pos [ Inline.Plain "text" ]
                  ; tags = []
                  ; marker = Some "TODO"
                  ; level = 1
@@ -604,7 +608,8 @@ let block =
           , `Quick
           , check_aux "- #tag"
               (Type.Heading
-                 { Type.title = [ Inline.Tag "tag" ]
+                 { Type.title =
+                     Type_op.inline_list_with_none_pos [ Inline.Tag "tag" ]
                  ; tags = []
                  ; marker = None
                  ; level = 1

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -6,6 +6,7 @@ let default_config : Conf.t =
   ; heading_to_list = false
   ; exporting_keep_properties = false
   ; ignore_heading_list_marker = false
+  ; inline_type_with_pos = false
   }
 
 let check_mldoc_type =
@@ -18,19 +19,20 @@ let check_aux source expect =
 let testcases =
   List.map (fun (case, level, f) -> Alcotest.test_case case level f)
 
+let paragraph l = Type.Paragraph (Type_op.inline_list_with_none_pos l)
+
 let inline =
-  let open Type in
   let module I = Inline in
   [ ( "emphasis"
     , testcases
         [ ( "normal bold"
           , `Quick
           , check_aux "*a b c*"
-              (Paragraph [ I.Emphasis (`Bold, [ I.Plain "a b c" ]) ]) )
+              (paragraph [ I.Emphasis (`Bold, [ I.Plain "a b c" ]) ]) )
         ; ( "normal bold(2)"
           , `Quick
           , check_aux "a*b*c"
-              (Paragraph
+              (paragraph
                  [ I.Plain "a"
                  ; I.Emphasis (`Bold, [ I.Plain "b" ])
                  ; I.Plain "c"
@@ -38,35 +40,35 @@ let inline =
         ; ( "normal italic"
           , `Quick
           , check_aux "/a b c/"
-              (Paragraph [ I.Emphasis (`Italic, [ I.Plain "a b c" ]) ]) )
+              (paragraph [ I.Emphasis (`Italic, [ I.Plain "a b c" ]) ]) )
         ; ( "normal underline"
           , `Quick
           , check_aux "_a b c_"
-              (Paragraph [ I.Emphasis (`Underline, [ I.Plain "a b c" ]) ]) )
+              (paragraph [ I.Emphasis (`Underline, [ I.Plain "a b c" ]) ]) )
         ; ( "not emphasis (1)"
           , `Quick
-          , check_aux "a * b*" (Paragraph [ I.Plain "a * b*" ]) )
+          , check_aux "a * b*" (paragraph [ I.Plain "a * b*" ]) )
         ; ( "not emphasis (2)"
           , `Quick
           , check_aux "a_b_c"
-              (Paragraph [ I.Plain "a"; I.Subscript [ I.Plain "b_c" ] ]) )
+              (paragraph [ I.Plain "a"; I.Subscript [ I.Plain "b_c" ] ]) )
         ; ( "contains underline"
           , `Quick
           , check_aux "_a _ a_"
-              (Paragraph [ I.Emphasis (`Underline, [ I.Plain "a _ a" ]) ]) )
+              (paragraph [ I.Emphasis (`Underline, [ I.Plain "a _ a" ]) ]) )
         ; ( "contains star"
           , `Quick
           , check_aux "*a * a*"
-              (Paragraph [ I.Emphasis (`Bold, [ I.Plain "a * a" ]) ]) )
+              (paragraph [ I.Emphasis (`Bold, [ I.Plain "a * a" ]) ]) )
         ; ( "left flanking delimiter"
           , `Quick
           , check_aux "hello_world_"
-              (Paragraph [ I.Plain "hello"; I.Subscript [ I.Plain "world_" ] ])
+              (paragraph [ I.Plain "hello"; I.Subscript [ I.Plain "world_" ] ])
           )
         ; ( "left flanking delimiter (2)"
           , `Quick
           , check_aux "hello,_world_"
-              (Paragraph
+              (paragraph
                  [ I.Plain "hello,"
                  ; I.Emphasis (`Underline, [ I.Plain "world" ])
                  ]) )
@@ -89,7 +91,7 @@ let block =
           , `Quick
           , check_aux "#+BEGIN_QUOTE\nfoo\nbar\n#+END_QUOTE"
               (Quote
-                 [ Paragraph
+                 [ paragraph
                      [ I.Plain "foo"
                      ; I.Break_Line
                      ; I.Plain "bar"


### PR DESCRIPTION
``` clojure
frontend.format.mldoc> (-> (parse-json  "- [[aaa[[bbb]]]]" (default-config :markdown false false true)) (util/json->clj))
[[["Heading"
   {:title
    [[["Nested_link"
       [{:content "[[aaa[[bbb]]]]",
         :children
         [["Label" "aaa"]
          ["Nested_link"
           [{:content "[[bbb]]", :children [["Label" "bbb"]]}
            {:start_pos 5, :end_pos 12}]]]}
        {:start_pos 0, :end_pos 14}]]
      {:start_pos 2, :end_pos 16}]],
    :tags [],
    :level 1,
    :anchor "",
    :meta {:timestamps [], :properties []},
    :unordered true,
    :size nil}]
  {:start_pos 0, :end_pos 16}]]
```