### PR TITLE
enhance: update inline link type

### DIFF
--- a/lib/export/html.ml
+++ b/lib/export/html.ml
@@ -112,7 +112,10 @@ and inline config t =
     in
     [ Xml.block (assoc kind l) (map_inline config data) ]
   | Entity e -> [ Xml.raw e.html ]
-  | Tag t -> [ Xml.block "a" ~attr:[ ("class", "tag") ] [ Xml.data t ] ]
+  | Tag t ->
+    [ Xml.block "a" ~attr:[ ("class", "tag") ]
+        [ Xml.data (Inline.hash_tag_value_string (Tag t)) ]
+    ]
   | Latex_Fragment (Displayed s) -> [ Xml.data ("\\[" ^ s ^ "\\]") ]
   | Latex_Fragment (Inline s) -> [ Xml.data ("\\(" ^ s ^ "\\)") ]
   | Target s -> [ Xml.block "a" ~attr:[ ("id", s) ] [ Xml.data s ] ]

--- a/lib/export/html.ml
+++ b/lib/export/html.ml
@@ -45,6 +45,8 @@ let handle_image_link url href label =
         []
     ]
   | Search _
+  | Page_ref _
+  | Block_ref _
   | File _ ->
     [ Xml.block "img" ~attr:[ ("src", href); ("title", Inline.asciis label) ] []
     ]

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -97,7 +97,7 @@ let rec inline state config (t : Inline.t) : t list =
       ) else
         map_raw_text [ s ]
     | Link l -> inline_link l
-    | Nested_link l -> inline_nested_link @@ fst l
+    | Nested_link l -> inline_nested_link l
     | Target s -> map_raw_text [ "<<"; s; ">>" ]
     | Subscript tl -> inline_subscript state config tl
     | Superscript tl -> inline_superscript state config tl

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -84,7 +84,7 @@ let rec inline state config (t : Inline.t) : t list =
       [ raw_text "  \n" ]
     | Verbatim s -> [ raw_text s ]
     | Code s -> map_raw_text [ "`"; s; "`" ] (* it's inline code *)
-    | Tag s -> map_raw_text [ "#"; s ]
+    | Tag s -> map_raw_text [ "#"; Inline.hash_tag_value_string (Tag s) ]
     | Spaces s ->
       if state.last_newline then
         []

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -120,7 +120,6 @@ let rec inline state config (t : Inline.t) : t list =
     | Inline_Source_Block { language; options; code } ->
       map_raw_text [ "src_"; language; "["; options; "]{"; code; "}" ]
     | Email e -> map_raw_text [ "<"; Email_address.to_string e; ">" ]
-    | Block_reference uuid -> block_reference uuid
     | Inline_Hiccup s -> map_raw_text [ s ]
     | Inline_Html s -> map_raw_text [ s ])
   in

--- a/lib/syntax/extended/hash_tag.ml
+++ b/lib/syntax/extended/hash_tag.ml
@@ -1,3 +1,4 @@
+open! Prelude
 open Angstrom
 open Parsers
 
@@ -22,6 +23,3 @@ let hashtag_name =
       List.cons <$> hashtag_name_part <*> m
       <|> (List.cons <$> hashtag_name_part <*> return []))
   >>| String.concat ""
-
-(* TODO: how to express begin of line? Otherwise the tag should be prefixed by spaces *)
-let parse = char '#' *> hashtag_name

--- a/lib/syntax/heading.ml
+++ b/lib/syntax/heading.ml
@@ -105,9 +105,9 @@ let parse config =
         let title =
           match pos_and_title with
           | None -> []
-          | Some (pos, title) -> (
+          | Some (_pos, title) -> (
             match parse_string ~consume:All (Inline.parse config) title with
-            | Ok title -> Type_op.inline_list_move_forward title pos
+            | Ok title -> title
             | Error _e -> [])
         in
         let title, tags =

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -158,7 +158,7 @@ let extract_macro_or_block_ref (il : Inline.t list) =
     (fun i ->
       match i with
       | Inline.Macro m when m.name = "embed" -> Some (`Macro m)
-      | Inline.Block_reference s -> Some (`Block_ref s)
+      | Inline.Link { url = Inline.Block_ref s; _ } -> Some (`Block_ref s)
       | _ -> None)
     il
 
@@ -257,7 +257,7 @@ let split_by_block_ref inline_list block_ref =
   List.find_idx
     (fun inline ->
       match inline with
-      | Inline.Block_reference s when s = block_ref -> true
+      | Inline.Link { url = Inline.Block_ref s; _ } when s = block_ref -> true
       | _ -> false)
     inline_list
   >>| fun (index, _) ->

--- a/lib/syntax/type_op.ml
+++ b/lib/syntax/type_op.ml
@@ -19,18 +19,17 @@ let inline_list_strip_pos (l : ('a * pos_meta option) list) : 'a list =
 let inline_with_pos i start_pos end_pos =
   (i, Some ({ start_pos; end_pos } : Pos.pos_meta))
 
+let inline_move_forward (i, pos) ~forward_pos =
+  ( i
+  , match pos with
+    | None -> None
+    | Some { start_pos; end_pos } ->
+      Some
+        { start_pos = start_pos + forward_pos; end_pos = end_pos + forward_pos }
+  )
+
 let inline_list_move_forward l forward_pos =
-  List.map
-    (fun (i, pos) ->
-      ( i
-      , match pos with
-        | None -> None
-        | Some { start_pos; end_pos } ->
-          Some
-            { start_pos = start_pos + forward_pos
-            ; end_pos = end_pos + forward_pos
-            } ))
-    l
+  List.map (inline_move_forward ~forward_pos) l
 
 let rec type_move_forawrd t forward_pos =
   match t with

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -302,6 +302,18 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
+        ; ( "page ref with label"
+          , `Quick
+          , check_aux "[label]([[page-ref]])"
+              (paragraph
+                 [ I.Link
+                     { url = I.Page_ref "page-ref"
+                     ; label = [ Plain "label" ]
+                     ; title = None
+                     ; full_text = "[label]([[page-ref]])"
+                     ; metadata = ""
+                     }
+                 ]) )
         ] )
   ; ( "inline-macro"
     , testcases

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -264,7 +264,7 @@ let inline =
           , check_aux "[[a]][b](c)"
               (paragraph
                  [ I.Link
-                     { url = I.Search "a"
+                     { url = I.Page_ref "a"
                      ; label = [ Plain "" ]
                      ; title = None
                      ; full_text = "[[a]]"

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -501,28 +501,48 @@ let inline =
     , testcases
         [ ( "endwith '.'"
           , `Quick
-          , check_aux "#tag." (paragraph [ I.Tag "tag"; I.Plain "." ]) )
+          , check_aux "#tag."
+              (paragraph [ I.Tag [ I.Plain "tag" ]; I.Plain "." ]) )
         ; ( "endwith ','"
           , `Quick
-          , check_aux "#tag," (paragraph [ I.Tag "tag"; I.Plain "," ]) )
+          , check_aux "#tag,"
+              (paragraph [ I.Tag [ I.Plain "tag" ]; I.Plain "," ]) )
         ; ( "endwith '\"'"
           , `Quick
-          , check_aux "#tag\"" (paragraph [ I.Tag "tag"; I.Plain "\"" ]) )
+          , check_aux "#tag\""
+              (paragraph [ I.Tag [ I.Plain "tag" ]; I.Plain "\"" ]) )
         ; ( "endwith several periods"
           , `Quick
-          , check_aux "#tag,.?" (paragraph [ I.Tag "tag"; I.Plain ",.?" ]) )
-        ; ("with '.'", `Quick, check_aux "#a.b.c" (paragraph [ I.Tag "a.b.c" ]))
+          , check_aux "#tag,.?"
+              (paragraph [ I.Tag [ I.Plain "tag" ]; I.Plain ",.?" ]) )
+        ; ( "with '.'"
+          , `Quick
+          , check_aux "#a.b.c" (paragraph [ I.Tag [ I.Plain "a.b.c" ] ]) )
         ; ( "with '.' and endwith '.'"
           , `Quick
-          , check_aux "#a.b.c." (paragraph [ I.Tag "a.b.c"; I.Plain "." ]) )
+          , check_aux "#a.b.c."
+              (paragraph [ I.Tag [ I.Plain "a.b.c" ]; I.Plain "." ]) )
         ; ( "with '.' and endwith '.' (2)"
           , `Quick
           , check_aux "#a.b.c. defg"
-              (paragraph [ I.Tag "a.b.c"; I.Plain ". defg" ]) )
+              (paragraph [ I.Tag [ I.Plain "a.b.c" ]; I.Plain ". defg" ]) )
         ; ( "with page-ref"
           , `Quick
           , check_aux "#a.[[b c d ]].e."
-              (paragraph [ I.Tag "a.[[b c d ]].e"; I.Plain "." ]) )
+              (paragraph
+                 [ I.Tag
+                     [ I.Plain "a."
+                     ; I.Link
+                         { url = I.Page_ref "b c d "
+                         ; label = [ I.Plain "" ]
+                         ; full_text = "[[b c d ]]"
+                         ; metadata = ""
+                         ; title = None
+                         }
+                     ; I.Plain ".e"
+                     ]
+                 ; I.Plain "."
+                 ]) )
         ] )
   ]
 
@@ -624,7 +644,8 @@ let block =
           , check_aux "- #tag"
               (Type.Heading
                  { Type.title =
-                     Type_op.inline_list_with_none_pos [ Inline.Tag "tag" ]
+                     Type_op.inline_list_with_none_pos
+                       [ Inline.Tag [ I.Plain "tag" ] ]
                  ; tags = []
                  ; marker = None
                  ; level = 1


### PR DESCRIPTION

- update `Tag of string` -> `Tag of Inline.t list`
- remove `inline.Block_reference s` type , which is moved to `inline.Link` with `inline.url=Block_ref <id>`
- update `inline.url` type
```ocaml
type url =
  | File of string
  | Search of string
  | Complex of complex
  | Page_ref of string  (* new added *)
  | Block_ref of string (* new added *)
```

```ocaml
(* before *)
Inline.Block_reference "id"
(* after *)
Inline.Link {url=inline.Block_ref "id"; ...}

```

```ocaml
(*
parse "[[a]]"
*)

(*before*)
Link
{ url = Search "a"
; label = [ Plain "" ]
; title = None
; full_text = "[[a]]"
; metadata = ""
}

(*after*)
Link
{ url = Page_ref "a"
; label = [ Plain "" ]
; title = None
; full_text = "[[a]]"
; metadata = ""
}
(*----------------------
parse "[label]([[aaa]])"
*)
(*before*)
Link
{ url = Search "[[page-ref]]"
; label = [ Plain "label" ]
; title = None
; full_text = "[label]([[page-ref]])"
; metadata = ""
}

(*after*)
Link
{ url = Page_ref "page-ref"
; label = [ Plain "label" ]
; title = None
; full_text = "[label]([[page-ref]])"
; metadata = ""}


```
