### PR TITLE
fix(opml): remove prefix spaces of text of exported opml

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -20,7 +20,6 @@ let main () =
                ; format = Org
                ; heading_to_list = false
                ; exporting_keep_properties = false
-               ; ignore_heading_list_marker = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
                }
@@ -34,7 +33,6 @@ let main () =
                ; format = Org
                ; heading_to_list = false
                ; exporting_keep_properties = false
-               ; ignore_heading_list_marker = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
                }
@@ -48,7 +46,6 @@ let main () =
                ; format = Markdown
                ; heading_to_list = false
                ; exporting_keep_properties = false
-               ; ignore_heading_list_marker = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
                }

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -34,7 +34,6 @@ let generate backend output _opts filename =
       ; format
       ; heading_to_list = true
       ; exporting_keep_properties = true
-      ; ignore_heading_list_marker = false
       ; inline_type_with_pos = false
       ; export_md_indent_style = Dashes
       }

--- a/js/lib.ml
+++ b/js/lib.ml
@@ -122,7 +122,6 @@ let _ =
            (Conf.of_yojson config_json, Reference.of_yojson references_json)
          with
          | Ok config, Ok references ->
-           let config = { config with ignore_heading_list_marker = true } in
            let ast = parse config str in
            let document = Document.from_ast (Some title) ast in
            let parsed_embed_blocks =

--- a/lib/export/conf.ml
+++ b/lib/export/conf.ml
@@ -42,7 +42,6 @@ type t =
   ; heading_to_list : bool (* export heading as list *)
   ; exporting_keep_properties : bool
         [@default false] (* keep properties when exporting *)
-  ; ignore_heading_list_marker : bool [@default false]
   ; inline_type_with_pos : bool [@default false]
   ; export_md_indent_style : indent_style [@default Dashes]
   }

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -296,10 +296,9 @@ and heading state config h =
   in
   let f () =
     let heading_or_list =
-      match (config.heading_to_list, config.ignore_heading_list_marker) with
-      | true, false -> [ Indent (state.current_level, 0); raw_text "-" ]
-      | true, true -> [ Indent (state.current_level, 0) ]
-      | false, _ ->
+      match config.heading_to_list with
+      | true -> [ Indent (state.current_level, 0); raw_text "-" ]
+      | false ->
         if unordered || level <= 0 then
           [ Indent (state.current_level, 0); raw_text "-" ]
         else

--- a/lib/transform/markdown_transformer.ml
+++ b/lib/transform/markdown_transformer.ml
@@ -17,7 +17,6 @@ end = struct
     ; format = Conf.Markdown
     ; heading_to_list = false
     ; exporting_keep_properties = false
-    ; ignore_heading_list_marker = false
     ; inline_type_with_pos = false
     ; export_md_indent_style = Conf.Dashes
     }

--- a/test/dune
+++ b/test/dune
@@ -23,16 +23,23 @@
  (modules test_export_markdown)
  (libraries alcotest mldoc))
 
+(executables
+ (names test_export_opml)
+ (modules test_export_opml)
+ (libraries alcotest mldoc))
+
 (rule
  (alias runtest)
  (deps
   (:md test_markdown.exe)
   (:org test_org.exe)
   (:zip test_zip.exe)
-  (:export-md test_export_markdown.exe))
+  (:export-md test_export_markdown.exe)
+  (:export-opml test_export_opml.exe))
  (action
   (progn
    (run %{md})
    (run %{org})
    (run %{zip})
-   (run %{export-md}))))
+   (run %{export-md})
+   (run %{export-opml}))))

--- a/test/gen_md_files.ml
+++ b/test/gen_md_files.ml
@@ -117,7 +117,8 @@ let config : Conf.t =
   ; format = Conf.Markdown
   ; heading_to_list = true
   ; exporting_keep_properties = false
-  ; ignore_heading_list_marker = false
+  ; inline_type_with_pos = false
+  ; export_md_indent_style = Dashes
   }
 
 (* ./gen_md_files.exe <page-num> <dir-num> *)

--- a/test/test_export_markdown.ml
+++ b/test/test_export_markdown.ml
@@ -5,7 +5,6 @@ let default_config : Conf.t =
   ; format = Conf.Markdown
   ; heading_to_list = false
   ; exporting_keep_properties = false
-  ; ignore_heading_list_marker = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
   }
@@ -153,4 +152,4 @@ let export_md =
         ] )
   ]
 
-let () = Alcotest.run "exporting-md" export_md
+let () = Alcotest.run "export-md" export_md

--- a/test/test_export_opml.ml
+++ b/test/test_export_opml.ml
@@ -1,0 +1,48 @@
+let default_config : Conf.t =
+  { toc = true
+  ; heading_number = true
+  ; keep_line_break = false
+  ; format = Conf.Markdown
+  ; heading_to_list = false
+  ; exporting_keep_properties = false
+  ; inline_type_with_pos = false
+  ; export_md_indent_style = Conf.Dashes
+  }
+
+let check_aux ?(config = default_config) source expect =
+  let tl = Mldoc_parser.parse config source in
+  let buf = Buffer.create 100 in
+  let output_buf = Xmlm.make_output ~indent:(Some 2) (`Buffer buf) in
+  let _ = Opml.blocks Reference.empty_parsed_t tl "title" output_buf in
+  fun _ ->
+    Alcotest.check Alcotest.string "check exported string" expect
+      (Buffer.contents buf)
+
+let testcases =
+  List.map (fun (case, level, f) -> Alcotest.test_case case level f)
+
+let testcase_list =
+  [ ( "export opml"
+    , testcases
+        [ ( "normal"
+          , `Quick
+          , check_aux "- line1\n  - line2\n    line3\n    - line4"
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+               <opml version=\"2.0\">\n\
+              \  <head>\n\
+              \    <title>\n\
+              \      title\n\
+              \    </title>\n\
+              \  </head>\n\
+              \  <body>\n\
+              \    <outline text=\"line1\">\n\
+              \      <outline text=\"line2\" _note=\"    line3&#10;\">\n\
+              \        <outline text=\"line4\"/>\n\
+              \      </outline>\n\
+              \    </outline>\n\
+              \  </body>\n\
+               </opml>" )
+        ] )
+  ]
+
+let () = Alcotest.run "export-opml" testcase_list

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -5,7 +5,6 @@ let default_config : Conf.t =
   ; format = Conf.Markdown
   ; heading_to_list = false
   ; exporting_keep_properties = false
-  ; ignore_heading_list_marker = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
   }

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -5,7 +5,6 @@ let default_config : Conf.t =
   ; format = Conf.Org
   ; heading_to_list = false
   ; exporting_keep_properties = false
-  ; ignore_heading_list_marker = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
   }


### PR DESCRIPTION
also remove `conf.ignore_heading_list_marker` option