### PR TITLE
feat: add remove meta-chars options when exporting

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -22,6 +22,7 @@ let main () =
                ; exporting_keep_properties = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
+               ; export_md_remove_options = []
                }
              in
              ignore (parse config doc_org))
@@ -35,6 +36,7 @@ let main () =
                ; exporting_keep_properties = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
+               ; export_md_remove_options = []
                }
              in
              ignore (parse config syntax_org))
@@ -48,6 +50,7 @@ let main () =
                ; exporting_keep_properties = false
                ; inline_type_with_pos = false
                ; export_md_indent_style = Dashes
+               ; export_md_remove_options = []
                }
              in
              ignore (parse config syntax_md))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -36,6 +36,7 @@ let generate backend output _opts filename =
       ; exporting_keep_properties = true
       ; inline_type_with_pos = false
       ; export_md_indent_style = Dashes
+      ; export_md_remove_options = []
       }
     in
     let ast = parse config (String.concat "\n" lines) in

--- a/lib/export/conf.ml
+++ b/lib/export/conf.ml
@@ -32,6 +32,11 @@ let indent_style_of_yojson = function
     | _ -> Ok Dashes)
   | _ -> Ok Dashes
 
+type meta_chars =
+  | Page_ref (* [[text]] *)
+  | Emphasis (* **text**, __text__, ... *)
+[@@deriving yojson]
+
 type t =
   { (* html: bool; *)
     (* hiccup: bool; *)
@@ -44,6 +49,7 @@ type t =
         [@default false] (* keep properties when exporting *)
   ; inline_type_with_pos : bool [@default false]
   ; export_md_indent_style : indent_style [@default Dashes]
+  ; export_md_remove_options : meta_chars list [@default []]
   }
 [@@deriving yojson]
 

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -527,7 +527,8 @@ let blocks refs config tl =
     | Spaces -> replace_heading_with_paragraph z'
     | NoIndent -> replace_heading_with_paragraph (flatten z')
   in
-  let v = to_value z'' in
+  let z''' = remove_meta_chars config.export_md_remove_options z'' in
+  let v = to_value z''' in
   blocks_aux (default_state ()) config v
 
 let directive kvs =

--- a/lib/export/opml.ml
+++ b/lib/export/opml.ml
@@ -14,6 +14,7 @@ let default_config =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Spaces
+  ; export_md_remove_options = []
   }
 
 let attr ?(uri = "") local value : Xmlm.attribute = ((uri, local), value)

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -582,7 +582,7 @@ let rec remove_meta_chars_internal2 remove_emphasis remove_page_ref (t : Type.t)
     Type.Table { header = header'; groups = groups'; col_groups }
   | _ -> t
 
-let remove_meta_chars (meta_chars : Conf.meta_chars list)
+let remove_meta_chars_aux (meta_chars : Conf.meta_chars list)
     (t : Type.t_with_pos_meta Z.t) =
   let remove_emphasis = List.mem Conf.Emphasis meta_chars in
   let remove_page_ref = List.mem Conf.Page_ref meta_chars in
@@ -604,3 +604,10 @@ let remove_meta_chars (meta_chars : Conf.meta_chars list)
         |> aux
   in
   aux root
+
+let remove_meta_chars (meta_chars : Conf.meta_chars list)
+    (t : Type.t_with_pos_meta Z.t) =
+  if List.length meta_chars = 0 then
+    t
+  else
+    remove_meta_chars_aux meta_chars t

--- a/lib/syntax/tree_type.mli
+++ b/lib/syntax/tree_type.mli
@@ -33,3 +33,11 @@ val replace_heading_with_paragraph :
 
 (** [flatten t] returns one-level tree *)
 val flatten : Type.t_with_pos_meta t -> Type.t_with_pos_meta t
+
+(** [remove_meta_chars] remove meta-chars.
+    - [[text]] -> text
+    - **text** -> text
+    - __text__ -> text
+    - ... *)
+val remove_meta_chars :
+  Conf.meta_chars list -> Type.t_with_pos_meta t -> Type.t_with_pos_meta t

--- a/lib/transform/markdown_transformer.ml
+++ b/lib/transform/markdown_transformer.ml
@@ -19,6 +19,7 @@ end = struct
     ; exporting_keep_properties = false
     ; inline_type_with_pos = false
     ; export_md_indent_style = Conf.Dashes
+    ; export_md_remove_options = []
     }
 
   let rec of_value v ~config =

--- a/test/gen_md_files.ml
+++ b/test/gen_md_files.ml
@@ -119,6 +119,7 @@ let config : Conf.t =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Dashes
+  ; export_md_remove_options = []
   }
 
 (* ./gen_md_files.exe <page-num> <dir-num> *)

--- a/test/test_export_markdown.ml
+++ b/test/test_export_markdown.ml
@@ -7,6 +7,7 @@ let default_config : Conf.t =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
+  ; export_md_remove_options = []
   }
 
 let refs : Reference.parsed_t =

--- a/test/test_export_opml.ml
+++ b/test/test_export_opml.ml
@@ -7,6 +7,7 @@ let default_config : Conf.t =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
+  ; export_md_remove_options = []
   }
 
 let check_aux ?(config = default_config) source expect =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -7,6 +7,7 @@ let default_config : Conf.t =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
+  ; export_md_remove_options = []
   }
 
 let check_mldoc_type =

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -7,6 +7,7 @@ let default_config : Conf.t =
   ; exporting_keep_properties = false
   ; inline_type_with_pos = false
   ; export_md_indent_style = Conf.Dashes
+  ; export_md_remove_options = []
   }
 
 let check_mldoc_type =


### PR DESCRIPTION
- remove page-ref , [[text]] -> text
- remove emphasis, `**text**` -> text, `__text__` -> text, and so on