### PR TITLE
fix(md): unescaped char in emphasis

### DIFF
--- a/lib/mldoc_parser.ml
+++ b/lib/mldoc_parser.ml
@@ -47,7 +47,12 @@ let parsers config =
 
 let parse config input =
   match parse_string ~consume:All (parsers config) input with
-  | Ok result -> Paragraph.concat_paragraph_lines config result
+  | Ok result ->
+    let ast = Paragraph.concat_paragraph_lines config result in
+    if Conf.is_markdown config then
+      List.map (fun (t, pos) -> (Type_op.md_unescaped t, pos)) ast
+    else
+      ast
   | Error err -> failwith err
 
 let load_file f =

--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -619,7 +619,8 @@ let quick_link =
 
 let org_link config =
   let link_type_and_url_part =
-    string "[[" *> take_while1 (fun c -> c <> ']') >>= fun url_part ->
+    string "[[" *> take_while1_include_backslash [ ']' ] (fun c -> c <> ']')
+    >>= fun url_part ->
     string "][" *> return `Other_link <|> return `Page_ref_link
     >>| fun link_type -> (link_type, url_part)
   in
@@ -674,7 +675,9 @@ let org_link config =
 
 (* helper for markdown_link and markdown_image *)
 let link_url_part =
-  string_contains_balanced_brackets [ ('(', ')') ] eol_chars >>= fun s ->
+  string_contains_balanced_brackets ~escape_chars:[ '('; ')' ] [ ('(', ')') ]
+    eol_chars
+  >>= fun s ->
   let len = String.length s in
   char ')' *> return s
   <|>
@@ -717,7 +720,7 @@ let markdown_link config =
   let label_part_delims = [ '`'; '['; ']' ] in
   let label_part_choices =
     choice
-      [ ( take_while1 (fun c ->
+      [ ( take_while1_include_backslash [ ']' ] (fun c ->
               non_eol c && (not @@ List.mem c label_part_delims))
         >>| fun s -> Plain s )
       ; ( peek_char >>= fun c ->

--- a/lib/syntax/type_op.ml
+++ b/lib/syntax/type_op.ml
@@ -54,19 +54,20 @@ let rec type_move_forawrd t forward_pos =
 let unescaped_md_string s =
   let open Bytes in
   let b = of_string s in
-  let n =
-    if length b = 0 then
-      ref 0
-    else
-      ref 1
-  in
-  for i = 0 to length b - 2 do
+  let n = ref 0 in
+  let i = ref 0 in
+  let lenb = length b in
+  while !i < lenb do
     n :=
       !n
       +
-      match get b i with
-      | '\\' when Parsers.is_md_escape_char (get b (i + 1)) -> 0
-      | _ -> 1
+      match get b !i with
+      | '\\' when !i + 1 < lenb && Parsers.is_md_escape_char (get b (!i + 1)) ->
+        i := !i + 2;
+        1
+      | _ ->
+        incr i;
+        1
   done;
   if !n = length b then
     s

--- a/lib/syntax/type_op.ml
+++ b/lib/syntax/type_op.ml
@@ -50,3 +50,105 @@ let rec type_move_forawrd t forward_pos =
   | Footnote_Definition (s, l) ->
     Footnote_Definition (s, inline_list_move_forward l forward_pos)
   | _ -> t
+
+let unescaped_md_string s =
+  let open Bytes in
+  let b = of_string s in
+  let n =
+    if length b = 0 then
+      ref 0
+    else
+      ref 1
+  in
+  for i = 0 to length b - 2 do
+    n :=
+      !n
+      +
+      match get b i with
+      | '\\' when Parsers.is_md_escape_char (get b (i + 1)) -> 0
+      | _ -> 1
+  done;
+  if !n = length b then
+    s
+  else
+    let b' = create !n in
+    n := 0;
+    let i = ref 0 in
+    let len_1 = length b - 1 in
+    while !i <= len_1 do
+      (match get b !i with
+      | '\\' when !i < len_1 ->
+        let c = get b (!i + 1) in
+        if Parsers.is_md_escape_char c then
+          set b' !n c
+        else (
+          set b' !n '\\';
+          incr n;
+          set b' !n c
+        );
+        incr i
+      | c -> set b' !n c);
+      incr n;
+      incr i
+    done;
+    to_string b'
+
+let map_plain t f =
+  let rec inline_aux (t : Inline.t) =
+    match t with
+    | Inline.Emphasis (em_type, tl) ->
+      Inline.Emphasis (em_type, List.map inline_aux tl)
+    | Inline.Tag tl -> Inline.Tag (List.map inline_aux tl)
+    | Inline.Plain s -> Inline.Plain (f s)
+    | Inline.Link link ->
+      let label = List.map inline_aux link.label in
+      Inline.Link { link with label }
+    | Inline.Subscript tl -> Inline.Subscript (List.map inline_aux tl)
+    | Inline.Superscript tl -> Inline.Superscript (List.map inline_aux tl)
+    | Inline.Footnote_Reference fr ->
+      Inline.Footnote_Reference
+        { fr with definition = Option.map (List.map inline_aux) fr.definition }
+    | _ -> t
+  in
+  let rec block_list_aux list_item =
+    let content' = List.map block_aux list_item.content in
+    let items = List.map block_list_aux list_item.items in
+    let name =
+      List.map (fun (t', pos) -> (inline_aux t', pos)) list_item.name
+    in
+    { list_item with content = content'; items; name }
+  and block_aux (t : Type.t) =
+    match t with
+    | Paragraph l ->
+      Paragraph (List.map (fun (t', pos) -> (inline_aux t', pos)) l)
+    | Heading heading ->
+      let title' =
+        List.map (fun (t', pos) -> (inline_aux t', pos)) heading.title
+      in
+      Heading { heading with title = title' }
+    | List l -> List (List.map block_list_aux l)
+    | Quote tl -> Quote (List.map block_aux tl)
+    | Custom (name, opts, data, s) ->
+      let data' = List.map block_aux data in
+      Custom (name, opts, data', s)
+    | Footnote_Definition (name, content) ->
+      let content' = List.map (fun (t', pos) -> (inline_aux t', pos)) content in
+      Footnote_Definition (name, content')
+    | Table table ->
+      let header = Option.map (List.map (List.map inline_aux)) table.header in
+      let groups =
+        List.map (List.map (List.map (List.map inline_aux))) table.groups
+      in
+      Table { table with header; groups }
+    | _ -> t
+  in
+  block_aux t
+
+(** unescape string in Type.Plain:
+    e.g. \* -> *
+    see also Parsers.md_escape_chars
+    text in code fence should preserve '\' *)
+let md_unescaped t = map_plain t unescaped_md_string
+
+(** TODO *)
+let md_escaped _t = failwith "not impl yet"

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -586,12 +586,42 @@ let inline =
           , check_aux "_a*b\\*_"
               (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b*" ]) ])
           )
-          (* TODO fix escaped chars in link *)
-          (* ; ( "link"
-           *   , `Quick
-           *   , check_aux "[[\\]]]"
-           *       (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b*" ]) ])
-           *   ) *)
+        ; ( "link (1)"
+          , `Quick
+          , check_aux "[[\\]]]"
+              (paragraph
+                 [ Inline.Link
+                     { url = Inline.Page_ref "]"
+                     ; label = [ Inline.Plain "" ]
+                     ; full_text = "[[\\]]]"
+                     ; metadata = ""
+                     ; title = None
+                     }
+                 ]) )
+        ; ( "link (2)"
+          , `Quick
+          , check_aux "[label\\](x)](xxx)"
+              (paragraph
+                 [ Inline.Link
+                     { url = Inline.Search "xxx"
+                     ; label = [ Inline.Plain "label](x)" ]
+                     ; full_text = "[label\\](x)](xxx)"
+                     ; metadata = ""
+                     ; title = None
+                     }
+                 ]) )
+        ; ( "link (3)"
+          , `Quick
+          , check_aux "[label](ur\\)l)"
+              (paragraph
+                 [ Inline.Link
+                     { url = Inline.Search "ur)l"
+                     ; label = [ Inline.Plain "label" ]
+                     ; full_text = "[label](ur\\)l)"
+                     ; metadata = ""
+                     ; title = None
+                     }
+                 ]) )
         ] )
   ]
 

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -570,6 +570,29 @@ let inline =
                      }
                  ]) )
         ] )
+  ; ( "escape metachars"
+    , testcases
+        [ ( "emphasis"
+          , `Quick
+          , check_aux "*a\\*b*"
+              (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b" ]) ])
+          )
+        ; ( "code"
+          , `Quick
+          , check_aux "`a\\``"
+              (paragraph [ Inline.Code "a\\"; Inline.Plain "`" ]) )
+        ; ( "nested emphasis"
+          , `Quick
+          , check_aux "_a*b\\*_"
+              (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b*" ]) ])
+          )
+          (* TODO fix escaped chars in link *)
+          (* ; ( "link"
+           *   , `Quick
+           *   , check_aux "[[\\]]]"
+           *       (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b*" ]) ])
+           *   ) *)
+        ] )
   ]
 
 let block =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -572,11 +572,16 @@ let inline =
         ] )
   ; ( "escape metachars"
     , testcases
-        [ ( "emphasis"
+        [ ( "emphasis(1)"
           , `Quick
           , check_aux "*a\\*b*"
               (paragraph [ Inline.Emphasis (`Italic, [ Inline.Plain "a*b" ]) ])
           )
+        ; ( "emphasis(2)"
+          , `Quick
+          , check_aux "*a\\\\\\*b*"
+              (paragraph
+                 [ Inline.Emphasis (`Italic, [ Inline.Plain "a\\*b" ]) ]) )
         ; ( "code"
           , `Quick
           , check_aux "`a\\``"


### PR DESCRIPTION
Fixed:
- emphasis :
   - `*a\*b\**` -> ![image](https://user-images.githubusercontent.com/5608710/128755717-faf2d70e-a1af-4a9f-a918-0b38a75f1ade.png)
   - `_a\_ a_` -> ![image](https://user-images.githubusercontent.com/5608710/128755782-dbcb1995-012a-49c0-a8b5-a0eea9dc8adf.png)
- quote
   - `\> dede` -> ![image](https://user-images.githubusercontent.com/5608710/128755959-70386203-2504-4fd0-8cca-249cd9dc76dc.png)
- link
   - `[lab\]el](ur\)l)` ->![image](https://user-images.githubusercontent.com/5608710/128842889-c9c334e1-a64c-4a01-ae7b-99ea65b051fe.png)
   - `[[\]]]` -> ![image](https://user-images.githubusercontent.com/5608710/128842940-94bf7ab7-4fce-4358-9fd0-38c4d12beb38.png)


TODO:
- ~fix unescape chars in inline.link~
- exported md should escape meta chars (will support this in another PR)


