### PR TITLE
fix(md): link label

### DIFF
--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -203,6 +203,19 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
+        ; ( "normal (2)"
+          , `Quick
+          , check_aux "[not label][label](url)"
+              (paragraph
+                 [ I.Plain "[not label]"
+                 ; I.Link
+                     { url = I.Search "url"
+                     ; label = [ Plain "label" ]
+                     ; title = None
+                     ; full_text = "[label](url)"
+                     ; metadata = ""
+                     }
+                 ]) )
         ; ( "also support org-link syntax"
           , `Quick
           , check_aux "[[http://foobar/path?query=123][label here]]"


### PR DESCRIPTION
fix issue https://github.com/logseq/logseq/issues/2622

|link | before| after|
|----|---|--|
|`[a][b](c)`|![image](https://user-images.githubusercontent.com/5608710/129823194-fbfad548-d20a-489c-baa2-6b3bf40935e5.png)|![image](https://user-images.githubusercontent.com/5608710/129823252-2d97c0df-cfb1-45a6-8137-edf806e0bff8.png)|