### PR TITLE
enhance: macro arg support arg in " pair, escape from sep-by comma

### DIFF
--- a/js/lib.ml
+++ b/js/lib.ml
@@ -13,25 +13,26 @@ let generate backend ?refs config doc output =
   let export = Exporters.find backend in
   Exporters.run export ~refs config doc output
 
-let mldoc_object = (object%js
-  method parseJson input config_json =
-    let config_json = Js.to_string config_json in
-    let config_json = Yojson.Safe.from_string config_json in
-    match Conf.of_yojson config_json with
-    | Ok config -> (
+let mldoc_object =
+  object%js
+    method parseJson input config_json =
+      let config_json = Js.to_string config_json in
+      let config_json = Yojson.Safe.from_string config_json in
+      match Conf.of_yojson config_json with
+      | Ok config -> (
         try
           let str = Js.to_string input in
           parse config str |> ast_to_json |> Js.string
         with error ->
           print_endline (Printexc.to_string error);
           input)
-    | Error e -> Js_of_ocaml.Js.string ("Config error: " ^ e)
+      | Error e -> Js_of_ocaml.Js.string ("Config error: " ^ e)
 
-  method parseInlineJson input config_json =
-    let config_json = Js.to_string config_json in
-    let config_json = Yojson.Safe.from_string config_json in
-    match Conf.of_yojson config_json with
-    | Ok config -> (
+    method parseInlineJson input config_json =
+      let config_json = Js.to_string config_json in
+      let config_json = Yojson.Safe.from_string config_json in
+      match Conf.of_yojson config_json with
+      | Ok config -> (
         let str = Js.to_string input in
         match parse_string ~consume:All (Mldoc.Inline.parse config) str with
         | Ok result ->
@@ -40,205 +41,200 @@ let mldoc_object = (object%js
         | Error e ->
           print_endline e;
           input)
-    | Error e -> Js_of_ocaml.Js.string ("Config error: " ^ e)
+      | Error e -> Js_of_ocaml.Js.string ("Config error: " ^ e)
 
-  method parseOPML input =
-    let str = Js.to_string input in
-    try Opml_parser.parse str |> ast_with_content_to_json |> Js.string
-    with error ->
-      print_endline (Printexc.to_string error);
-      input
+    method parseOPML input =
+      let str = Js.to_string input in
+      try Opml_parser.parse str |> ast_with_content_to_json |> Js.string
+      with error ->
+        print_endline (Printexc.to_string error);
+        input
 
-  method export to_format input config_json references =
-    let to_format = Js.to_string to_format in
-    let str = Js.to_string input in
-    let config_json = Js.to_string config_json in
-    let references_json =
-      Js.to_string references |> Yojson.Safe.from_string
-    in
-    let buffer = Buffer.create 1024 in
-    let config_json = Yojson.Safe.from_string config_json in
-    match
-      (Conf.of_yojson config_json, Reference.of_yojson references_json)
-    with
-    | Ok config, references ->
-      let (embed_blocks, embed_pages) = match references with
-        | Ok references ->
-          (references.embed_blocks, references.embed_pages)
-        | Error _ ->
-          ([], [])
+    method export to_format input config_json references =
+      let to_format = Js.to_string to_format in
+      let str = Js.to_string input in
+      let config_json = Js.to_string config_json in
+      let references_json =
+        Js.to_string references |> Yojson.Safe.from_string
       in
-      let ast = parse config str in
-      let parsed_embed_blocks =
-        List.map
-          (fun (k, (content_include_children, content)) ->
-             ( k
-             , ( fst @@ unzip @@ parse config content_include_children
-               , fst @@ unzip @@ parse config content ) ))
-          embed_blocks
-      in
-      let parsed_embed_pages =
-        List.map
-          (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
-          embed_pages
-      in
-      let refs : Reference.parsed_t =
-        { parsed_embed_blocks; parsed_embed_pages }
-      in
-      let document = Document.from_ast None ast in
-      let _ =
-        Sys_js.set_channel_flusher stdout (fun s ->
-            Buffer.add_string buffer s)
-      in
-      generate to_format ~refs config document stdout;
-      flush stdout;
-      Js_of_ocaml.Js.string (Buffer.contents buffer)
-    | Error error, _ -> Js_of_ocaml.Js.string error
+      let buffer = Buffer.create 1024 in
+      let config_json = Yojson.Safe.from_string config_json in
+      match
+        (Conf.of_yojson config_json, Reference.of_yojson references_json)
+      with
+      | Ok config, references ->
+        let embed_blocks, embed_pages =
+          match references with
+          | Ok references -> (references.embed_blocks, references.embed_pages)
+          | Error _ -> ([], [])
+        in
+        let ast = parse config str in
+        let parsed_embed_blocks =
+          List.map
+            (fun (k, (content_include_children, content)) ->
+              ( k
+              , ( fst @@ unzip @@ parse config content_include_children
+                , fst @@ unzip @@ parse config content ) ))
+            embed_blocks
+        in
+        let parsed_embed_pages =
+          List.map
+            (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
+            embed_pages
+        in
+        let refs : Reference.parsed_t =
+          { parsed_embed_blocks; parsed_embed_pages }
+        in
+        let document = Document.from_ast None ast in
+        let _ =
+          Sys_js.set_channel_flusher stdout (fun s ->
+              Buffer.add_string buffer s)
+        in
+        generate to_format ~refs config document stdout;
+        flush stdout;
+        Js_of_ocaml.Js.string (Buffer.contents buffer)
+      | Error error, _ -> Js_of_ocaml.Js.string error
 
-  method parseAndExportMarkdown input config_json references =
-    let str = Js.to_string input in
-    let config_json = Js.to_string config_json in
-    let references_json =
-      Js.to_string references |> Yojson.Safe.from_string
-    in
-    let buffer = Buffer.create 1024 in
-    let config_json = Yojson.Safe.from_string config_json in
-    match
-      (Conf.of_yojson config_json, Reference.of_yojson references_json)
-    with
-    | Ok config, Ok references ->
-      let ast = parse config str in
-      let parsed_embed_blocks =
-        List.map
-          (fun (k, (content_include_children, content)) ->
-             ( k
-             , ( fst @@ unzip @@ parse config content_include_children
-               , fst @@ unzip @@ parse config content ) ))
-          references.embed_blocks
+    method parseAndExportMarkdown input config_json references =
+      let str = Js.to_string input in
+      let config_json = Js.to_string config_json in
+      let references_json =
+        Js.to_string references |> Yojson.Safe.from_string
       in
-      let parsed_embed_pages =
-        List.map
-          (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
-          references.embed_pages
-      in
-      let refs : Reference.parsed_t =
-        { parsed_embed_blocks; parsed_embed_pages }
-      in
-      let document = Document.from_ast None ast in
-      let _ =
-        Sys_js.set_channel_flusher stdout (fun s ->
-            Buffer.add_string buffer s)
-      in
-      generate "markdown" ~refs config document stdout;
-      flush stdout;
-      Js_of_ocaml.Js.string (Buffer.contents buffer)
-    | Error error, _ -> Js_of_ocaml.Js.string error
-    | _, Error error -> Js_of_ocaml.Js.string error
+      let buffer = Buffer.create 1024 in
+      let config_json = Yojson.Safe.from_string config_json in
+      match
+        (Conf.of_yojson config_json, Reference.of_yojson references_json)
+      with
+      | Ok config, Ok references ->
+        let ast = parse config str in
+        let parsed_embed_blocks =
+          List.map
+            (fun (k, (content_include_children, content)) ->
+              ( k
+              , ( fst @@ unzip @@ parse config content_include_children
+                , fst @@ unzip @@ parse config content ) ))
+            references.embed_blocks
+        in
+        let parsed_embed_pages =
+          List.map
+            (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
+            references.embed_pages
+        in
+        let refs : Reference.parsed_t =
+          { parsed_embed_blocks; parsed_embed_pages }
+        in
+        let document = Document.from_ast None ast in
+        let _ =
+          Sys_js.set_channel_flusher stdout (fun s ->
+              Buffer.add_string buffer s)
+        in
+        generate "markdown" ~refs config document stdout;
+        flush stdout;
+        Js_of_ocaml.Js.string (Buffer.contents buffer)
+      | Error error, _ -> Js_of_ocaml.Js.string error
+      | _, Error error -> Js_of_ocaml.Js.string error
 
-  method parseAndExportOPML input config_json title references =
-    let str = Js.to_string input in
-    let config_json = Js.to_string config_json in
-    let config_json = Yojson.Safe.from_string config_json in
-    let title = Js.to_string title in
-    let references_json =
-      Js.to_string references |> Yojson.Safe.from_string
-    in
-    let buffer = Buffer.create 1024 in
-    match
-      (Conf.of_yojson config_json, Reference.of_yojson references_json)
-    with
-    | Ok config, Ok references ->
-      let ast = parse config str in
-      let document = Document.from_ast (Some title) ast in
-      let parsed_embed_blocks =
-        List.map
-          (fun (k, (content_include_children, content)) ->
-             ( k
-             , ( fst @@ unzip @@ parse config content_include_children
-               , fst @@ unzip @@ parse config content ) ))
-          references.embed_blocks
+    method parseAndExportOPML input config_json title references =
+      let str = Js.to_string input in
+      let config_json = Js.to_string config_json in
+      let config_json = Yojson.Safe.from_string config_json in
+      let title = Js.to_string title in
+      let references_json =
+        Js.to_string references |> Yojson.Safe.from_string
       in
-      let parsed_embed_pages =
-        List.map
-          (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
-          references.embed_pages
-      in
-      let refs : Reference.parsed_t =
-        { parsed_embed_blocks; parsed_embed_pages }
-      in
-      let _ =
-        Sys_js.set_channel_flusher stdout (fun s ->
-            Buffer.add_string buffer s)
-      in
-      generate "opml" ~refs config document stdout;
-      flush stdout;
-      Js.string (Buffer.contents buffer)
-    | Error error, _ -> Js.string ("json->config err: " ^ error)
-    | _, Error error -> Js.string ("json->refs err: " ^ error)
+      let buffer = Buffer.create 1024 in
+      match
+        (Conf.of_yojson config_json, Reference.of_yojson references_json)
+      with
+      | Ok config, Ok references ->
+        let ast = parse config str in
+        let document = Document.from_ast (Some title) ast in
+        let parsed_embed_blocks =
+          List.map
+            (fun (k, (content_include_children, content)) ->
+              ( k
+              , ( fst @@ unzip @@ parse config content_include_children
+                , fst @@ unzip @@ parse config content ) ))
+            references.embed_blocks
+        in
+        let parsed_embed_pages =
+          List.map
+            (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
+            references.embed_pages
+        in
+        let refs : Reference.parsed_t =
+          { parsed_embed_blocks; parsed_embed_pages }
+        in
+        let _ =
+          Sys_js.set_channel_flusher stdout (fun s ->
+              Buffer.add_string buffer s)
+        in
+        generate "opml" ~refs config document stdout;
+        flush stdout;
+        Js.string (Buffer.contents buffer)
+      | Error error, _ -> Js.string ("json->config err: " ^ error)
+      | _, Error error -> Js.string ("json->refs err: " ^ error)
 
-  method astExportMarkdown ast config_json references =
-    let ast = Js.to_string ast |> Yojson.Safe.from_string in
-    let config_json =
-      Js.to_string config_json |> Yojson.Safe.from_string
-    in
-    let references_json =
-      Js.to_string references |> Yojson.Safe.from_string
-    in
-    let buffer = Buffer.create 1024 in
-    match
-      ( Conf.of_yojson config_json
-      , Reference.of_yojson references_json
-      , Type.blocks_of_yojson ast )
-    with
-    | Ok config, Ok references, Ok ast ->
-      let parsed_embed_blocks =
-        List.map
-          (fun (k, (content_include_children, content)) ->
-             ( k
-             , ( fst @@ unzip @@ parse config content_include_children
-               , fst @@ unzip @@ parse config content ) ))
-          references.embed_blocks
+    method astExportMarkdown ast config_json references =
+      let ast = Js.to_string ast |> Yojson.Safe.from_string in
+      let config_json = Js.to_string config_json |> Yojson.Safe.from_string in
+      let references_json =
+        Js.to_string references |> Yojson.Safe.from_string
       in
-      let parsed_embed_pages =
-        List.map
-          (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
-          references.embed_pages
-      in
-      let refs : Reference.parsed_t =
-        { parsed_embed_blocks; parsed_embed_pages }
-      in
-      let document = Document.from_ast None ast in
-      let _ =
-        Sys_js.set_channel_flusher stdout (fun s ->
-            Buffer.add_string buffer s)
-      in
-      generate "markdown" ~refs config document stdout;
-      flush stdout;
-      Js_of_ocaml.Js.string (Buffer.contents buffer)
-    | Error error, _, _ ->
-      Js_of_ocaml.Js.string ("json->config err: " ^ error)
-    | _, Error error, _ ->
-      Js_of_ocaml.Js.string ("json->references err: " ^ error)
-    | _, _, Error error -> Js_of_ocaml.Js.string ("json->ast err: " ^ error)
+      let buffer = Buffer.create 1024 in
+      match
+        ( Conf.of_yojson config_json
+        , Reference.of_yojson references_json
+        , Type.blocks_of_yojson ast )
+      with
+      | Ok config, Ok references, Ok ast ->
+        let parsed_embed_blocks =
+          List.map
+            (fun (k, (content_include_children, content)) ->
+              ( k
+              , ( fst @@ unzip @@ parse config content_include_children
+                , fst @@ unzip @@ parse config content ) ))
+            references.embed_blocks
+        in
+        let parsed_embed_pages =
+          List.map
+            (fun (k, v) -> (k, fst @@ unzip @@ parse config v))
+            references.embed_pages
+        in
+        let refs : Reference.parsed_t =
+          { parsed_embed_blocks; parsed_embed_pages }
+        in
+        let document = Document.from_ast None ast in
+        let _ =
+          Sys_js.set_channel_flusher stdout (fun s ->
+              Buffer.add_string buffer s)
+        in
+        generate "markdown" ~refs config document stdout;
+        flush stdout;
+        Js_of_ocaml.Js.string (Buffer.contents buffer)
+      | Error error, _, _ -> Js_of_ocaml.Js.string ("json->config err: " ^ error)
+      | _, Error error, _ ->
+        Js_of_ocaml.Js.string ("json->references err: " ^ error)
+      | _, _, Error error -> Js_of_ocaml.Js.string ("json->ast err: " ^ error)
 
-  method anchorLink s =
-    let s = Js.to_string s in
-    Js_of_ocaml.Js.string (Type_parser.Heading.anchor_link s)
+    method anchorLink s =
+      let s = Js.to_string s in
+      Js_of_ocaml.Js.string (Type_parser.Heading.anchor_link s)
 
-  method timestampToString input =
-    let str = Js.to_string input in
-    let json = Yojson.Safe.from_string str in
-    match Timestamp.of_yojson json with
-    | Ok t -> Timestamp.to_string t |> Js.string
-    | Error error -> Js_of_ocaml.Js.string error
+    method timestampToString input =
+      let str = Js.to_string input in
+      let json = Yojson.Safe.from_string str in
+      match Timestamp.of_yojson json with
+      | Ok t -> Timestamp.to_string t |> Js.string
+      | Error error -> Js_of_ocaml.Js.string error
 
-  method rangeToString input =
-    let str = Js.to_string input in
-    let json = Yojson.Safe.from_string str in
-    match Range.of_yojson json with
-    | Ok t -> Range.to_string t |> Js.string
-    | Error error -> Js_of_ocaml.Js.string error
-end)
+    method rangeToString input =
+      let str = Js.to_string input in
+      let json = Yojson.Safe.from_string str in
+      match Range.of_yojson json with
+      | Ok t -> Range.to_string t |> Js.string
+      | Error error -> Js_of_ocaml.Js.string error
+  end
 
-let _ =
-  Js.export "Mldoc" mldoc_object
+let _ = Js.export "Mldoc" mldoc_object

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -25,7 +25,7 @@ let map_raw_text = List.map raw_text
 let flatten_map f l = List.flatten (List.map f l)
 
 let export_properties_and_not_empty config kvs =
-  config.exporting_keep_properties && List.length(kvs) > 1
+  config.exporting_keep_properties && List.length kvs > 1
 
 type refs = Reference.parsed_t
 
@@ -59,16 +59,16 @@ let raw_text_indent state config s =
       let ls =
         lines s
         |> flatten_map (fun l ->
-            [ indent_with_2_spacemore state.current_level config
-            ; raw_text (l ^ "\n")
-            ])
+               [ indent_with_2_spacemore state.current_level config
+               ; raw_text (l ^ "\n")
+               ])
       in
       let ls_rev = List.rev ls in
       List.rev
         (match ls_rev with
-         | RawText s :: tl ->
-           newline :: raw_text (String.sub s 0 (String.length s - 1)) :: tl
-         | _ -> ls_rev)
+        | RawText s :: tl ->
+          newline :: raw_text (String.sub s 0 (String.length s - 1)) :: tl
+        | _ -> ls_rev)
     else
       [ raw_text s ]
   in
@@ -82,53 +82,53 @@ let rec inline state config (t : Inline.t) : t list =
     indent_with_2_spacemore state.current_level config
     ::
     (match t with
-     | Emphasis em -> emphasis state config em
-     | Break_Line ->
-       state.last_newline <- true;
-       [ raw_text "\n" ]
-     | Hard_Break_Line ->
-       state.last_newline <- true;
-       [ raw_text "  \n" ]
-     | Verbatim s -> [ raw_text s ]
-     | Code s -> map_raw_text [ "`"; s; "`" ] (* it's inline code *)
-     | Tag s -> map_raw_text [ "#"; Inline.hash_tag_value_string (Tag s) ]
-     | Spaces s ->
-       if state.last_newline then
-         []
-       else
-         map_raw_text [ s ]
-     | Plain s ->
-       if state.last_newline then (
-         state.last_newline <- false;
-         map_raw_text [ String.ltrim s ]
-       ) else
-         map_raw_text [ s ]
-     | Link l -> inline_link l
-     | Nested_link l -> inline_nested_link l
-     | Target s -> map_raw_text [ "<<"; s; ">>" ]
-     | Subscript tl -> inline_subscript state config tl
-     | Superscript tl -> inline_superscript state config tl
-     | Footnote_Reference fr -> footnote_reference fr
-     | Cookie c -> cookie c
-     | Latex_Fragment lf -> latex_fragment lf
-     | Macro m -> macro m
-     | Entity e -> entity e
-     | Timestamp t -> timestamp t
-     | Radio_Target s ->
-       map_raw_text [ "<<<"; s; ">>>" ] (* FIXME: not parsed in md parser? *)
-     | Export_Snippet (name, content) ->
-       [ raw_text "@@"
-       ; raw_text name
-       ; raw_text ":"
-       ; Space
-       ; raw_text content
-       ; raw_text "@@"
-       ]
-     | Inline_Source_Block { language; options; code } ->
-       map_raw_text [ "src_"; language; "["; options; "]{"; code; "}" ]
-     | Email e -> map_raw_text [ "<"; Email_address.to_string e; ">" ]
-     | Inline_Hiccup s -> map_raw_text [ s ]
-     | Inline_Html s -> map_raw_text [ s ])
+    | Emphasis em -> emphasis state config em
+    | Break_Line ->
+      state.last_newline <- true;
+      [ raw_text "\n" ]
+    | Hard_Break_Line ->
+      state.last_newline <- true;
+      [ raw_text "  \n" ]
+    | Verbatim s -> [ raw_text s ]
+    | Code s -> map_raw_text [ "`"; s; "`" ] (* it's inline code *)
+    | Tag s -> map_raw_text [ "#"; Inline.hash_tag_value_string (Tag s) ]
+    | Spaces s ->
+      if state.last_newline then
+        []
+      else
+        map_raw_text [ s ]
+    | Plain s ->
+      if state.last_newline then (
+        state.last_newline <- false;
+        map_raw_text [ String.ltrim s ]
+      ) else
+        map_raw_text [ s ]
+    | Link l -> inline_link l
+    | Nested_link l -> inline_nested_link l
+    | Target s -> map_raw_text [ "<<"; s; ">>" ]
+    | Subscript tl -> inline_subscript state config tl
+    | Superscript tl -> inline_superscript state config tl
+    | Footnote_Reference fr -> footnote_reference fr
+    | Cookie c -> cookie c
+    | Latex_Fragment lf -> latex_fragment lf
+    | Macro m -> macro m
+    | Entity e -> entity e
+    | Timestamp t -> timestamp t
+    | Radio_Target s ->
+      map_raw_text [ "<<<"; s; ">>>" ] (* FIXME: not parsed in md parser? *)
+    | Export_Snippet (name, content) ->
+      [ raw_text "@@"
+      ; raw_text name
+      ; raw_text ":"
+      ; Space
+      ; raw_text content
+      ; raw_text "@@"
+      ]
+    | Inline_Source_Block { language; options; code } ->
+      map_raw_text [ "src_"; language; "["; options; "]{"; code; "}" ]
+    | Email e -> map_raw_text [ "<"; Email_address.to_string e; ">" ]
+    | Inline_Hiccup s -> map_raw_text [ s ]
+    | Inline_Html s -> map_raw_text [ s ])
   in
   let _ =
     match t with
@@ -159,22 +159,22 @@ and emphasis state config (typ, tl) =
   | `Bold ->
     wrap_with tl
       (if outside_em_symbol = Some '*' then
-         "__"
-       else
-         "**")
+        "__"
+      else
+        "**")
   | `Strike_through -> wrap_with tl "~~"
   | `Highlight -> wrap_with tl "^^"
   | `Italic ->
     wrap_with tl
       (if outside_em_symbol = Some '*' then
-         "_"
-       else
-         "*")
+        "_"
+      else
+        "*")
   | `Underline ->
     List.flatten
     @@ List.map
-      (fun e -> Space :: inline { state with outside_em_symbol } config e)
-      tl
+         (fun e -> Space :: inline { state with outside_em_symbol } config e)
+         tl
 
 and inline_link { full_text; _ } = [ raw_text full_text ]
 
@@ -254,8 +254,7 @@ and block state config t =
       latex_env state config name options content
     | Displayed_Math s ->
       [ Space; raw_text "$$"; raw_text s; raw_text "$$"; Space ]
-    | Drawer (name, lines) ->
-      drawer state config name lines
+    | Drawer (name, lines) -> drawer state config name lines
     | Property_Drawer kvs ->
       if export_properties_and_not_empty config kvs then
         property_drawer state config "PROPERTIES" kvs
@@ -313,9 +312,9 @@ and heading state config h =
     @ flatten_map (fun e -> Space :: inline state config e) (List.map fst title)
     @ [ Space
       ; (if List.length tags > 0 then
-           raw_text @@ ":" ^ String.concat ":" tags ^ ":"
-         else
-           raw_text "")
+          raw_text @@ ":" ^ String.concat ":" tags ^ ":"
+        else
+          raw_text "")
       ; newline
       ]
   in
@@ -331,73 +330,73 @@ and heading state config h =
 
 and list state config l =
   (fun l ->
-     if List.length l > 0 then
-       l @ [ TwoNewlines ]
-     else
-       l)
+    if List.length l > 0 then
+      l @ [ TwoNewlines ]
+    else
+      l)
   @@ List.flatten
   @@ List.map
-    (fun { content; items; number; name; checkbox; _ } ->
-       let state' = { state with current_level = state.current_level + 1 } in
-       let name' =
-         flatten_map (inline state config)
-           (Type_op.inline_list_strip_pos name)
-       in
-       let content' = flatten_map (block state' config) content in
-       (* Definition Lists content if name isn't empty  *)
-       let content'' =
-         if name' <> [] then
-           List.flatten
-           @@ List.map
-             (fun l ->
-                List.flatten
-                  [ [ raw_text ": " ]; block state' config l; [ newline ] ])
-             content
-         else
-           content'
-       in
-       let name'' =
-         if List.length name' > 0 then
-           name' @ [ newline ]
-         else
-           []
-       and number' =
-         match number with
-         | Some n -> raw_text @@ string_of_int n ^ ". "
-         | None when List.length name = 0 -> raw_text "* "
-         | None -> raw_text ""
-       and checkbox' =
-         match checkbox with
-         | Some true -> raw_text "[X]"
-         | Some false -> raw_text "[ ]"
-         | None -> raw_text ""
-       and indent' =
-         if state'.current_level > 0 then
-           raw_text @@ String.make state'.current_level '\t'
-         else
-           raw_text ""
-       and items' = list state' config items in
-       List.flatten
-         [ [ indent' ]
-         ; [ number' ]
-         ; [ checkbox' ]
-         ; [ Space ]
-         ; name''
-         ; content''
-         ; [ newline ]
-         ; items'
-         ; [ newline ]
-         ])
-    l
+       (fun { content; items; number; name; checkbox; _ } ->
+         let state' = { state with current_level = state.current_level + 1 } in
+         let name' =
+           flatten_map (inline state config)
+             (Type_op.inline_list_strip_pos name)
+         in
+         let content' = flatten_map (block state' config) content in
+         (* Definition Lists content if name isn't empty  *)
+         let content'' =
+           if name' <> [] then
+             List.flatten
+             @@ List.map
+                  (fun l ->
+                    List.flatten
+                      [ [ raw_text ": " ]; block state' config l; [ newline ] ])
+                  content
+           else
+             content'
+         in
+         let name'' =
+           if List.length name' > 0 then
+             name' @ [ newline ]
+           else
+             []
+         and number' =
+           match number with
+           | Some n -> raw_text @@ string_of_int n ^ ". "
+           | None when List.length name = 0 -> raw_text "* "
+           | None -> raw_text ""
+         and checkbox' =
+           match checkbox with
+           | Some true -> raw_text "[X]"
+           | Some false -> raw_text "[ ]"
+           | None -> raw_text ""
+         and indent' =
+           if state'.current_level > 0 then
+             raw_text @@ String.make state'.current_level '\t'
+           else
+             raw_text ""
+         and items' = list state' config items in
+         List.flatten
+           [ [ indent' ]
+           ; [ number' ]
+           ; [ checkbox' ]
+           ; [ Space ]
+           ; name''
+           ; content''
+           ; [ newline ]
+           ; items'
+           ; [ newline ]
+           ])
+       l
 
 and example state config sl =
   flatten_map
     (fun l ->
-       [ indent_with_2_spacemore state.current_level config
-       ; RawText "    "
-       ; RawText l
-       ; newline
-       ])
+      [ indent_with_2_spacemore state.current_level config
+      ; RawText "    "
+      ; RawText l
+      ; newline
+      ])
     sl
 
 and src state config { lines; language; _ } =
@@ -418,14 +417,14 @@ and src state config { lines; language; _ } =
 and quote state config tl =
   flatten_map
     (fun l ->
-       List.flatten
-         [ [ indent_with_2_spacemore state.current_level config
-           ; raw_text ">"
-           ; Space
-           ]
-         ; block state config l
-         ; [ TwoNewlines ]
-         ])
+      List.flatten
+        [ [ indent_with_2_spacemore state.current_level config
+          ; raw_text ">"
+          ; Space
+          ]
+        ; block state config l
+        ; [ TwoNewlines ]
+        ])
     tl
 
 and latex_env state config name options content =
@@ -458,8 +457,8 @@ and property_drawer state config name kvs =
       [ [ raw_text @@ ":" ^ name ^ ":"; newline ]
       ; flatten_map
           (fun (k, v) ->
-             (raw_text_indent state config @@ ":" ^ k ^ ":")
-             @ [ Space; raw_text v; newline ])
+            (raw_text_indent state config @@ ":" ^ k ^ ":")
+            @ [ Space; raw_text v; newline ])
           kvs
       ; [ raw_text ":END:"; newline ]
       ]
@@ -483,8 +482,8 @@ and table state config { header; groups; _ } =
         [ [ indent_with_2_spacemore state.current_level config ]
         ; flatten_map
             (fun col ->
-               Space :: raw_text "|" :: Space
-               :: flatten_map (inline state config) col)
+              Space :: raw_text "|" :: Space
+              :: flatten_map (inline state config) col)
             header
         ; [ Space; raw_text "|" ]
         ]
@@ -495,9 +494,9 @@ and table state config { header; groups; _ } =
              List.flatten
                [ flatten_map
                    (fun col ->
-                      indent_with_2_spacemore state.current_level config
-                      :: Space :: raw_text "|" :: Space
-                      :: flatten_map (inline state config) col)
+                     indent_with_2_spacemore state.current_level config
+                     :: Space :: raw_text "|" :: Space
+                     :: flatten_map (inline state config) col)
                    row
                ; [ Space; raw_text "|"; newline ]
                ]))
@@ -549,15 +548,15 @@ let directive kvs =
     let sep_line = [ newline; raw_text "---"; newline ] in
     sep_line
     @ flatten_map
-      (fun (name, value) ->
-         [ newline
-         ; raw_text name
-         ; raw_text ":"
-         ; Space
-         ; raw_text value
-         ; newline
-         ])
-      kvs
+        (fun (name, value) ->
+          [ newline
+          ; raw_text name
+          ; raw_text ":"
+          ; Space
+          ; raw_text value
+          ; newline
+          ])
+        kvs
     @ sep_line
 
 module String_Tree_Value = struct

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -470,7 +470,7 @@ let remove_last_newlines lines =
   match last_opt lines with
   | None -> lines
   | Some line ->
-    if (line = "\n") then
+    if line = "\n" then
       drop_last 1 lines
     else
       lines

--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -939,11 +939,12 @@ let macro_name = take_while1 (fun c -> c <> '}' && c <> '(' && c <> ' ')
 let macro_arg config =
   Nested_link.parse config
   >>| (fun l -> l.content)
-  <|> string "[[" *> take_while1 (fun c -> c <> ']')
-  <* string "]]"
-  >>| (fun s -> "[[" ^ s ^ "]]")
+  <|> page_ref
   <|> ( string "((" *> take_while1 (fun c -> c <> ')') <* string "))"
       >>| fun s -> "((" ^ s ^ "))" )
+  <|> ( char '"' *> take_while1_include_backslash [ '"' ] (fun c -> c <> '"')
+      <* char '"'
+      >>| fun s -> "\"" ^ s ^ "\"" )
   <|> take_while1 (fun c -> not @@ List.mem c [ ',' ])
 
 let macro_args config =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -422,6 +422,15 @@ let inline =
                      ; arguments = [ "[[A,B]]"; "((C,D))"; "E" ]
                      }
                  ]) )
+        ; ( "args(2)"
+          , `Quick
+          , check_aux "{{macroname [[A,B]], ((C,D)), E, \"F,G\"}}"
+              (paragraph
+                 [ I.Macro
+                     { I.Macro.name = "macroname"
+                     ; arguments = [ "[[A,B]]"; "((C,D))"; "E"; "\"F,G\"" ]
+                     }
+                 ]) )
         ] )
   ; ( "drawer"
     , testcases


### PR DESCRIPTION
`{{macro "a,r,g1", arg2}}` -> macro name: macro, macro args: ["\\"a,r,g1\\"", "arg2"]