### PR TITLE
fix: use lowercase pagename when search references

### DIFF
--- a/lib/export/reference.ml
+++ b/lib/export/reference.ml
@@ -1,7 +1,8 @@
 type t =
   { (* (block-uuid, (content-include-children, content)) list *)
     embed_blocks : (string * (string * string)) list
-  ; (* (page-name, content) list *)
+  ; (* (page-name, content) list
+       all page-names is lowercase *)
     embed_pages : (string * string) list
   }
 [@@deriving yojson]
@@ -9,7 +10,8 @@ type t =
 type parsed_t =
   { (** (block-uuid, (content-include-children, content)) list *)
     parsed_embed_blocks : (string * (Type.t list * Type.t list)) list
-  ; (** (page-name, content) list *)
+  ; (** (page-name, content) list
+        all page-names is lowercase *)
     parsed_embed_pages : (string * Type.t list) list
   }
 

--- a/lib/syntax/tree_type.ml
+++ b/lib/syntax/tree_type.ml
@@ -171,7 +171,7 @@ let macro_embed macro_argument (refs : Reference.parsed_t) =
       try String.(trim @@ sub arg 2 (length arg - 4)) with _ -> ""
     in
     if starts_with arg "[[" then
-      let pagename = value in
+      let pagename = String.lowercase_ascii value in
       match List.assoc_opt pagename refs.parsed_embed_pages with
       | Some tl ->
         let t = of_blocks_without_pos tl |> to_value in


### PR DESCRIPTION
page-name in references should be lowercase,
and use lowercase page-name when searching in references