### PR TITLE
fix: org-mode headline with tags

### DIFF
--- a/lib/syntax/heading0.ml
+++ b/lib/syntax/heading0.ml
@@ -155,7 +155,23 @@ struct
                         @ Type_op.inline_list_with_none_pos
                             [ Inline.Plain prefix ]
                     in
-                    (title, remove is_blank tags)
+                    let open Option in
+                    let last_plain =
+                      List.nth_opt title (List.length title - 1)
+                      >>| fun (inline_t, pos) ->
+                      ( (match inline_t with
+                        | Inline.Plain s -> Inline.Plain (String.rtrim s ^ " ")
+                        | _ -> inline_t)
+                      , pos )
+                    in
+                    let title' =
+                      if Option.is_some last_plain then
+                        let _, butlast_title = butlast title in
+                        List.append butlast_title [ Option.get last_plain ]
+                      else
+                        title
+                    in
+                    (title', remove is_blank tags)
                   | _ -> (title, [])
                 else
                   (title, [])

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -177,6 +177,49 @@ let block =
                  ; pos_meta = { start_pos = 59; end_pos = 95 }
                  }) )
         ] )
+  ; ( "Headline with tags"
+    , testcases
+        [ ( "(1)"
+          , `Quick
+          , check_aux "* aaa     :bb:cc:"
+              (Type.Heading
+                 { title = [ (I.Plain "aaa ", None) ]
+                 ; tags = [ "bb"; "cc" ]
+                 ; marker = None
+                 ; level = 1
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = "aaa"
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = None
+                 }) )
+        ; ( "(2)"
+          , `Quick
+          , check_aux "* aaa [[link][label]]     :bb:cc:"
+              (Type.Heading
+                 { title =
+                     [ (I.Plain "aaa ", None)
+                     ; ( I.Link
+                           { I.url = I.Search "link"
+                           ; label = [ I.Plain "label" ]
+                           ; title = None
+                           ; full_text = "[[link][label]]"
+                           ; metadata = ""
+                           }
+                       , None )
+                     ]
+                 ; tags = [ "bb"; "cc" ]
+                 ; marker = None
+                 ; level = 1
+                 ; numbering = None
+                 ; priority = None
+                 ; anchor = "aaa_label"
+                 ; meta = { Type.timestamps = []; properties = [] }
+                 ; unordered = true
+                 ; size = None
+                 }) )
+        ] )
   ]
 
 let () = Alcotest.run "mldoc" @@ List.concat [ block; inline ]


### PR DESCRIPTION
related info: https://github.com/llcc/logseq-discussion/blob/master/org-discussion.org#52-headline-with-tags-%E7%9A%84%E7%A9%BA%E6%A0%BC%E9%97%AE%E9%A2%98