### PR TITLE
feat(export): replace cloze macro with its content

### DIFF
--- a/lib/export/html.ml
+++ b/lib/export/html.ml
@@ -182,19 +182,22 @@ and inline config t =
         ]
     ]
   | Macro { name; arguments } -> (
-    try
-      let value = List.assoc name !macros in
-      let buff = Buffer.create (String.length value) in
-      Buffer.add_substitute buff
-        (fun v -> try List.nth arguments (int_of_string v - 1) with _ -> v)
-        value;
-      let content = Buffer.contents buff in
-      match
-        Angstrom.parse_string ~consume:All (Inline.parse config) content
-      with
-      | Ok inlines -> map_inline config (List.map fst inlines)
-      | Error _e -> [ Xml.empty ]
-    with Not_found -> [ Xml.empty ])
+    if name = "cloze" then
+      [ Xml.Data (String.concat "," arguments) ]
+    else
+      try
+        let value = List.assoc name !macros in
+        let buff = Buffer.create (String.length value) in
+        Buffer.add_substitute buff
+          (fun v -> try List.nth arguments (int_of_string v - 1) with _ -> v)
+          value;
+        let content = Buffer.contents buff in
+        match
+          Angstrom.parse_string ~consume:All (Inline.parse config) content
+        with
+        | Ok inlines -> map_inline config (List.map fst inlines)
+        | Error _e -> [ Xml.empty ]
+      with Not_found -> [ Xml.empty ])
   | _ -> [ Xml.empty ]
 
 let get_int_option name =

--- a/lib/export/markdown.ml
+++ b/lib/export/markdown.ml
@@ -206,12 +206,16 @@ and latex_fragment = function
   | Displayed s -> [ Space; raw_text "$$"; raw_text s; raw_text "$$"; Space ]
 
 and macro m =
-  map_raw_text
-  @@
-  if List.length m.arguments > 0 then
-    [ "{{"; m.name; "("; String.concat "," m.arguments; ")}}" ]
+  (* replace cloze macro with its content *)
+  if m.name = "cloze" then
+    [ raw_text (String.concat "," m.arguments) ]
   else
-    [ "{{"; m.name; "}}" ]
+    map_raw_text
+    @@
+    if List.length m.arguments > 0 then
+      [ "{{"; m.name; "("; String.concat "," m.arguments; ")}}" ]
+    else
+      [ "{{"; m.name; "}}" ]
 
 and entity { unicode; _ } = [ raw_text unicode ]
 

--- a/test/test_export_markdown.ml
+++ b/test/test_export_markdown.ml
@@ -166,6 +166,13 @@ let export_md =
           , `Quick
           , check_aux "- # line1\n  - ##  TODO line2\n  - line3"
               "- # line1\n\t- ## TODO line2\n\t- line3" )
+        ; ( "replace cloze with its content (1)"
+          , `Quick
+          , check_aux "- {{cloze content1,content2}}" "- content1,content2" )
+        ; ( "replace cloze with its content (2)"
+          , `Quick
+          , check_aux "- {{cloze (content1,content2)}}" "- (content1,content2)"
+          )
         ] )
   ]
 


### PR DESCRIPTION
replace `{{cloze content}}` with `content` when exporting