### PR TITLE
fix(md): page-ref contains colon

### DIFF
--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -650,7 +650,7 @@ let org_link_1 config =
           Search url_text
         else
           try
-            Scanf.sscanf url_text "%[^:]://%[^\n]" (fun protocol link ->
+            Scanf.sscanf url_text "%[^:]:%[^\n]" (fun protocol link ->
                 let link' =
                   if String.length link < 2 then
                     link
@@ -705,15 +705,7 @@ let org_link_2 =
     else
       try
         Scanf.sscanf s "%[^:]://%[^\n]" (fun protocol link ->
-            let link' =
-              if String.length link < 2 then
-                link
-              else if String.sub link 0 2 = "//" then
-                String.sub link 2 (String.length link - 2)
-              else
-                link
-            in
-            Complex { protocol; link = link' })
+            Complex { protocol; link })
       with _ -> Page_ref s
   in
   let full_text = Printf.sprintf "[[%s]]" s in
@@ -897,8 +889,8 @@ let markdown_link config =
     label_part link_url_part metadata
 
 let markdown_link_or_page_ref config =
-  org_link config
-  <|> ( page_ref >>| fun s ->
+  page_ref
+  >>| (fun s ->
         let inner_s = String.sub s 2 (String.length s - 4) in
         Link
           { url = Page_ref inner_s
@@ -906,7 +898,7 @@ let markdown_link_or_page_ref config =
           ; title = None
           ; full_text = s
           ; metadata = ""
-          } )
+          })
   <|> markdown_link config
 
 let link config =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -229,18 +229,27 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
-        ; ( "also support org-link syntax"
+        ; ( "normal (3)"
           , `Quick
-          , check_aux "[[http://foobar/path?query=123][label here]]"
+          , check_aux "[[page:name]]"
               (paragraph
                  [ I.Link
-                     { url =
-                         I.Complex
-                           { protocol = "http"; link = "foobar/path?query=123" }
-                     ; label = [ Plain "label here" ]
+                     { url = I.Page_ref "page:name"
+                     ; label = [ Plain "" ]
                      ; title = None
-                     ; full_text =
-                         "[[http://foobar/path?query=123][label here]]"
+                     ; full_text = "[[page:name]]"
+                     ; metadata = ""
+                     }
+                 ]) )
+        ; ( "normal (4)"
+          , `Quick
+          , check_aux "[[page://name]]"
+              (paragraph
+                 [ I.Link
+                     { url = I.Page_ref "page://name"
+                     ; label = [ Plain "" ]
+                     ; title = None
+                     ; full_text = "[[page://name]]"
                      ; metadata = ""
                      }
                  ]) )

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -131,6 +131,30 @@ let inline =
                      ; metadata = ""
                      }
                  ]) )
+        ; ( "normal (5)"
+          , `Quick
+          , check_aux "[[exam:ple]]"
+              (paragraph
+                 [ I.Link
+                     { url = I.Page_ref "exam:ple"
+                     ; label = [ I.Plain "" ]
+                     ; title = None
+                     ; full_text = "[[exam:ple]]"
+                     ; metadata = ""
+                     }
+                 ]) )
+        ; ( "normal (6)"
+          , `Quick
+          , check_aux "[[exam:ple][label]]"
+              (paragraph
+                 [ I.Link
+                     { url = I.Complex { protocol = "exam"; link = "ple" }
+                     ; label = [ I.Plain "label" ]
+                     ; title = None
+                     ; full_text = "[[exam:ple][label]]"
+                     ; metadata = ""
+                     }
+                 ]) )
         ] )
   ]
 


### PR DESCRIPTION
1. md page-ref contains (: | ://) should be parsed to a normal
page-ref instead a link
2. org-link is not supported in md anymore