### PR TITLE
fix: markdown front matter property value tailed with space

### DIFF
--- a/lib/syntax/markdown_front_matter.ml
+++ b/lib/syntax/markdown_front_matter.ml
@@ -13,7 +13,7 @@ open Type
 let kv_parse =
   let key_parser = take_while1 (fun c -> c <> ':' && non_eol c) in
   let sep_parser = char ':' <* spaces in
-  let value_parser = take_till is_eol <|> (end_of_input >>| fun _ -> "") in
+  let value_parser = take_till is_space_eol <|> (end_of_input >>| fun _ -> "") in
   let p =
     lift3
       (fun key _sep value -> Directive (key, value))

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -511,9 +511,22 @@ let inline =
                :END:\r\n"
               (Property_Drawer
                  [ ("now", "1614485729874"); ("done", "1614485743195") ]) )
+        ; ( "front-matter-endwith-space"
+          , `Quick
+          , check_aux
+              "---\r\n\
+               now: 1614485729874   \n\
+               done: 1614485743195   \n\
+               ---\r\n"
+              (Property_Drawer
+                 [ ("now", "1614485729874"); ("done", "1614485743195") ]) )
         ; ( "simplified-property-syntax"
           , `Quick
           , check_aux "a.b.c:: def\na-b-c::"
+              (Property_Drawer [ ("a.b.c", "def"); ("a-b-c", "") ]) )
+        ; ( "simplified-endwith-space"
+          , `Quick
+          , check_aux "a.b.c:: def      \na-b-c::"
               (Property_Drawer [ ("a.b.c", "def"); ("a-b-c", "") ]) )
         ; ( "empty-property"
           , `Quick


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/4693

I don't know OCaml 🤣 