### PR TITLE
Some fixes to dune project and .ocaml file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.8)
+(name mldoc)

--- a/mldoc.opam
+++ b/mldoc.opam
@@ -41,6 +41,6 @@ build: [
   ]
 ]
 pin-depends: [
-  [ "angstrom.dev" "git://github.com/logseq/angstrom#fork" ]
-  [ "xmlm.dev" "git://github.com/logseq/xmlm#fork" ]
+  [ "angstrom.dev" "git+https://github.com/logseq/angstrom#fork" ]
+  [ "xmlm.dev" "git+https://github.com/logseq/xmlm#fork" ]
 ]


### PR DESCRIPTION
Hello,
When I tried `opam pin add mldoc ~/github/mldoc --working-dir` I got errors about dune project and opam dependencies (`angstrom` and `xmlm`). This patch fixes my issues.