### PR TITLE
Update deprecated Command.run

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -28,7 +28,7 @@ let config =
 let outline_config = { config with parse_outline_only = true }
 
 let main () =
-  Command.run
+  Command_unix.run
     (Bench.make_command
        [ Bench.Test.create ~name:"Inline parse (doc)" (fun () ->
              let p = Inline.parse config in

--- a/bench/dune
+++ b/bench/dune
@@ -1,6 +1,6 @@
 (executable
  (name bench)
- (libraries angstrom mldoc core core_bench))
+ (libraries angstrom mldoc core core_bench core_unix.command_unix))
 
 (alias
  (name bench)


### PR DESCRIPTION
Need to change Command.run due to new API.

Documentation link: https://ocaml.org/p/core_unix/v0.14.0/doc/Command_unix/index.html#val-run