### PR TITLE
fix: inline entity separators

### DIFF
--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -481,9 +481,9 @@ let target =
         | _ -> true)
     >>= fun s -> return @@ Target s )
 
-(* \alpha *)
+(* \alpha, \alpha{} *)
 let entity =
-  char '\\' *> take_while1 is_letter >>| fun s ->
+  char '\\' *> take_while1 is_letter <* optional (string "{}") >>| fun s ->
   try
     let entity = Entity.find s in
     Entity entity

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -647,6 +647,39 @@ let inline =
           , check_aux "[as`d](http://dwdw)`"
               (paragraph [ I.Plain "[as"; I.Code "d](http://dwdw)" ]) )
         ] )
+  ; ( "inline-entity"
+    , testcases
+        [
+          ( "space separator"
+            , `Quick
+            , check_aux "\\Delta G"
+              (paragraph
+                 [ I.Entity
+                 { name = "Delta"
+                 ; latex = "\\Delta"
+                 ; latex_mathp = true
+                 ; html = "&Delta;"
+                 ; ascii = "Delta"
+                 ; unicode = "Δ"}
+                 ; I.Plain " G" ]))
+          ; ( "no separator"
+            , `Quick
+            , check_aux "\\DeltaG"
+              (paragraph
+                 [ I.Plain "DeltaG" ]))
+          ; ( "{} separator"
+          , `Quick
+          , check_aux "\\Delta{}G"
+              (paragraph
+                 [ I.Entity
+                 { name = "Delta"
+                 ; latex = "\\Delta"
+                 ; latex_mathp = true
+                 ; html = "&Delta;"
+                 ; ascii = "Delta"
+                 ; unicode = "Δ"}
+                 ; I.Plain "G" ]))
+                 ])
   ; ( "emphasis"
     , testcases
         [ ( "normal"


### PR DESCRIPTION
This aims to address a long-standing gripe I have when using Logseq!

In Emacs's `org-mode`, `{}` can be used to separate items like `\Delta` from any text that follows. This is consistent with how `{}` is used to explicitly mark where sub/superscripts end. Here are some examples from Emacs that I've converted into test cases:

This:
![image](https://user-images.githubusercontent.com/6251883/212492626-a6759007-b7f9-4c5d-bfbd-f88038547029.png)

Becomes:
![image](https://user-images.githubusercontent.com/6251883/212492663-9ac96e49-1206-43b3-99aa-a35b36e058a7.png)

One way I've continued to deviate from this Emacs behavior is by transforming `\DeltaG` into `DeltaG` (without the backslash). This keeps the same behavior that already existed and seems to fit a bit better with the way Logseq displays things?

I'm happy to change that too!

(Also, sorry if I'm made some simple mistakes in this short PR, today is the first time I've ever read / written OCaml code and I'm working off of a familiarity with Haskell!)