### PR TITLE
AST output format; new configuration options & fix some bugs

### DIFF
--- a/js/package/bin/convert.cmd.js
+++ b/js/package/bin/convert.cmd.js
@@ -6,6 +6,7 @@ var yargs = require('yargs'),
 yargs.usage('Usage: mldoc convert [options]')
   .example('mldoc convert -i', 'Reads from stdin and outputs to stdout')
   .example('mldoc convert -i foo.org -o bar.html', 'Reads \'foo.org\' and writes to \'bar.html\'')
+  .example('mldoc convert -i foo.md -f ast', 'Reads \'foo.md\' and writes its AST to stdout')
   .version()
   .alias('v', 'version')
   .config('c')

--- a/js/package/bin/convert.cmd.js
+++ b/js/package/bin/convert.cmd.js
@@ -86,20 +86,24 @@ function run () {
   messenger.printMsg('Converting to ' + to_format);
 
   // TODO: add config options
-  output_content = MO.export(to_format, content,
-    JSON.stringify({
-      "toc": true,
-      "parse_outline_only": false,
-      "heading_number": true,
-      "keep_line_break": false,
-      "format": format,
-      "heading_to_list": false,
-      "exporting_keep_properties": true,
-      "inline_type_with_pos": false,
-      "export_md_remove_options": [],
-      "hiccup_in_block": true}
-    ),
-    '{}');
+  config = JSON.stringify({
+    "toc": false,
+    "parse_outline_only": false,
+    "heading_number": false,
+    "keep_line_break": false,
+    "format": format,
+    "heading_to_list": false,
+    "exporting_keep_properties": true,
+    "inline_type_with_pos": false,
+    "export_md_remove_options": [],
+    "hiccup_in_block": true,
+  });
+  if (to_format === 'ast')
+    output_content = JSON.stringify(
+      JSON.parse( MO.parseInlineJson(content, config) ),
+      null, 4);
+  else
+    output_content = MO.export(to_format, content, config, '{}');
 
   // write the output
   messenger.printMsg('Writing data to ' + writeMode + '...');

--- a/js/package/bin/convert.cmd.js
+++ b/js/package/bin/convert.cmd.js
@@ -14,30 +14,30 @@ yargs.usage('Usage: mldoc convert [options]')
   .help('h')
   .alias('h', 'help')
   .option('i', {
-    alias : 'input',
+    alias: 'input',
     describe: 'Input source. Usually a org file. If omitted or empty, reads from stdin',
     type: 'string'
   })
   .option('o', {
-    alias : 'output',
+    alias: 'output',
     describe: 'Output target. Usually a html file. If omitted or empty, writes to stdout',
     type: 'string',
     default: false
   })
   .option('f', {
-    alias : 'format',
+    alias: 'format',
     describe: 'Output format',
     type: 'string',
     default: false
   })
   .option('u', {
-    alias : 'encoding',
+    alias: 'encoding',
     describe: 'Input encoding',
     type: 'string',
     default: 'utf8'
   })
   .option('a', {
-    alias : 'append',
+    alias: 'append',
     describe: 'Append data to output instead of overwriting',
     type: 'string',
     default: false
@@ -114,7 +114,11 @@ function run () {
   function readFromStdIn () {
     try {
       var size = fs.fstatSync(process.stdin.fd).size;
-      return size > 0 ? fs.readSync(process.stdin.fd, size)[0] : '';
+      if (size === 0)
+        return ''
+      const buffer = Buffer.alloc(size)
+      fs.readSync(process.stdin.fd, buffer)
+      return buffer.toString(argv.encoding)
     } catch (e) {
       var err = new Error('Could not read from stdin, reason: ' + e.message);
       messenger.errorExit(err);

--- a/js/package/bin/convert.cmd.js
+++ b/js/package/bin/convert.cmd.js
@@ -36,6 +36,11 @@ yargs.usage('Usage: mldoc convert [options]')
     type: 'string',
     default: 'utf8'
   })
+  .option('with-pos', {
+    describe: 'Include positions meta',
+    type: 'boolean',
+    default: false
+  })
   .option('a', {
     alias: 'append',
     describe: 'Append data to output instead of overwriting',
@@ -95,7 +100,7 @@ function run () {
     "format": format,
     "heading_to_list": false,
     "exporting_keep_properties": true,
-    "inline_type_with_pos": false,
+    "inline_type_with_pos": argv.withPos,
     "export_md_remove_options": [],
     "hiccup_in_block": true,
   });

--- a/js/package/bin/convert.cmd.js
+++ b/js/package/bin/convert.cmd.js
@@ -39,7 +39,7 @@ yargs.usage('Usage: mldoc convert [options]')
   .option('a', {
     alias: 'append',
     describe: 'Append data to output instead of overwriting',
-    type: 'string',
+    type: 'boolean',
     default: false
   })
   .option('q', {
@@ -68,7 +68,7 @@ function run () {
       messenger = new Messenger(msgMode, argv.quiet, argv.mute),
       read = (readMode === 'stdin') ? readFromStdIn : readFromFile,
       write = (writeMode === 'stdout') ? writeToStdOut : writeToFile,
-      content, output_content;
+      content, output_content, config;
 
   var extension = (readMode === 'file') ? argv.i.split('.').pop() : '';
   var format = (extension === 'org') ? 'Org' : 'Markdown';


### PR DESCRIPTION
- fix: `stdout` cannot be used as output
- fix: read from `stdin` doesn't work
- fix: `html` output format cannot be used
- fix: arg `append` is not a boolean type

+ feat: added `-f`, `-format` param → output format can be different than extension
+ feat: added `ast` output format
+ feat: added `-with-pos` option to include positions meta info
