### PR TITLE
Add support for braces-only mode in subscript

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -22,6 +22,7 @@ let config =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let outline_config = { config with parse_outline_only = true }

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -41,6 +41,7 @@ let generate backend output _opts filename =
       ; export_md_remove_options = []
       ; hiccup_in_block = true
       ; enable_drawers = true
+      ; skip_no_braces = false
       }
     in
     let ast = parse config (String.concat "\n" lines) in

--- a/lib/export/conf.ml
+++ b/lib/export/conf.ml
@@ -54,6 +54,7 @@ type t =
   ; export_md_remove_options : meta_chars list [@default []]
   ; hiccup_in_block : bool [@default true]
   ; enable_drawers : bool [@default true]
+  ; skip_no_braces : bool [@default false]
   }
 [@@deriving yojson]
 

--- a/lib/export/opml.ml
+++ b/lib/export/opml.ml
@@ -19,6 +19,7 @@ let default_config =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let attr ?(uri = "") local value : Xmlm.attribute = ((uri, local), value)

--- a/lib/syntax/inline.ml
+++ b/lib/syntax/inline.ml
@@ -503,11 +503,11 @@ let gen_script config s f =
     many1 (choice [ emphasis config; plain config; whitespaces; entity ])
   in
   string (s ^ "{") *> take_while1 (fun c -> non_eol c && c <> '}')
-  <* char '}' <|> p1
+  <* char '}' <|> (if config.skip_no_braces then fail "plain" else p1)
   >>| fun s ->
-  match parse_string ~consume:All p s with
-  | Ok result -> f @@ concat_plains_without_pos result
-  | Error _e -> f [ Plain s ]
+    match parse_string ~consume:All p s with
+    | Ok result -> f @@ concat_plains_without_pos result
+    | Error _e -> f [ Plain s ]
 
 let subscript config = gen_script config "_" (fun x -> Subscript x)
 

--- a/lib/transform/markdown_transformer.ml
+++ b/lib/transform/markdown_transformer.ml
@@ -24,6 +24,7 @@ end = struct
     ; export_md_remove_options = []
     ; hiccup_in_block = true
     ; enable_drawers = true
+    ; skip_no_braces = false
     }
 
   let rec of_value v ~config =

--- a/test/test_export_markdown.ml
+++ b/test/test_export_markdown.ml
@@ -12,6 +12,7 @@ let default_config : Conf.t =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let refs : Reference.parsed_t =

--- a/test/test_export_opml.ml
+++ b/test/test_export_opml.ml
@@ -12,6 +12,7 @@ let default_config : Conf.t =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let check_aux ?(config = default_config) source expect =

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -12,6 +12,7 @@ let default_config : Conf.t =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let check_mldoc_type =

--- a/test/test_org.ml
+++ b/test/test_org.ml
@@ -12,14 +12,33 @@ let default_config : Conf.t =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let check_mldoc_type =
   Alcotest.check (Alcotest.testable Type.pp ( = )) "check mldoc type"
 
-let check_aux source expect =
-  let result = Mldoc.Parser.parse default_config source |> List.hd |> fst in
+let check_aux ?(config = default_config) source expect =
+  let result = Mldoc.Parser.parse config source |> List.hd |> fst in
   fun _ -> check_mldoc_type expect result
+
+let braces_config : Conf.t =
+  { toc = true
+  ; parse_outline_only = false
+  ; heading_number = true
+  ; keep_line_break = false
+  ; format = Conf.Org
+  ; heading_to_list = false
+  ; exporting_keep_properties = false
+  ; inline_type_with_pos = false
+  ; inline_skip_macro = false
+  ; export_md_indent_style = Conf.Dashes
+  ; export_md_remove_options = []
+  ; hiccup_in_block = true
+  ; enable_drawers = true
+  ; skip_no_braces = true
+  }
+
 
 let testcases =
   List.map (fun (case, level, f) -> Alcotest.test_case case level f)
@@ -60,6 +79,18 @@ let inline =
           , `Quick
           , check_aux "a_b_c"
               (paragraph [ I.Plain "a"; I.Subscript [ I.Plain "b_c" ] ]) )
+        ; ( "not emphasis (3)"
+          , `Quick
+          , check_aux "a_{bc}"
+              (paragraph [ I.Plain "a"; I.Subscript [ I.Plain "bc" ] ]) )
+        ; ( "not emphasis (4) - force braces"
+          , `Quick
+          , check_aux ~config:braces_config "a_{bc}"
+              (paragraph [ I.Plain "a"; I.Subscript [ I.Plain "bc" ] ]) )
+        ; ( "not emphasis (5) - force braces"
+          , `Quick
+          , check_aux ~config:braces_config "a_bc"
+              (paragraph [ I.Plain "a_bc" ]) )
         ; ( "contains underline"
           , `Quick
           , check_aux "_a _ a_"

--- a/test/test_outline_markdown.ml
+++ b/test/test_outline_markdown.ml
@@ -12,6 +12,7 @@ let default_config : Conf.t =
   ; export_md_remove_options = []
   ; hiccup_in_block = true
   ; enable_drawers = true
+  ; skip_no_braces = false
   }
 
 let check_mldoc_type =


### PR DESCRIPTION
This change adds a config option `skip_no_braces`, which allows for rendering sub- and superscript without braces as plain.

If `skip_no_braces` is set to true, `a_{bc}` should result in a<sub>bc</sub>, and `a_bc` - in a_bc.