### PR TITLE
Optimize outline parsing allocations and fast-path scalar properties

### DIFF
--- a/lib/syntax/md_outline.ml
+++ b/lib/syntax/md_outline.ml
@@ -763,22 +763,33 @@ let rec parse_list_items config lines i min_indent =
 
 let parse config input =
   let raw_lines = String.split_on_char '\n' input in
-  let lines = Array.of_list (List.map rstrip_cr raw_lines) in
+  let lines = Array.of_list raw_lines in
+  (* [split_on_char] has already allocated every line.  Reuse those strings
+     for the overwhelmingly common LF input rather than allocating an
+     intermediate mapped list; only replace CRLF lines in place. *)
+  Array.iteri
+    (fun i line ->
+      let stripped = rstrip_cr line in
+      if stripped != line then lines.(i) <- stripped)
+    lines;
   let n = Array.length lines in
   let line_starts =
-    let arr = Array.make (max n 1) 0 in
-    let pos = ref 0 in
-    for idx = 0 to n - 1 do
-      arr.(idx) <- !pos;
-      let nl =
-        if idx + 1 < n then
-          1
-        else
-          0
-      in
-      pos := !pos + String.length lines.(idx) + nl
-    done;
-    arr
+    if config.parse_outline_only then
+      [||]
+    else
+      let arr = Array.make (max n 1) 0 in
+      let pos = ref 0 in
+      for idx = 0 to n - 1 do
+        arr.(idx) <- !pos;
+        let nl =
+          if idx + 1 < n then
+            1
+          else
+            0
+        in
+        pos := !pos + String.length lines.(idx) + nl
+      done;
+      arr
   in
   let src_end_pos body_i =
     let rec find j =

--- a/lib/syntax/property.ml
+++ b/lib/syntax/property.ml
@@ -18,11 +18,31 @@ open Conf
 
 let property_references config s =
   let config = { config with inline_skip_macro = true } in
+  (* Most Logseq properties are scalar values (ids, dates, booleans, and so
+     on).  Running the complete inline grammar for all of them dominates an
+     outline parse even though only tags and links survive the filter below.
+     Every syntax accepted by that filter starts with one of these bytes, so
+     cheaply reject scalar values before constructing an Angstrom parser. *)
+  let may_have_reference =
+    let length = String.length s in
+    let rec loop i =
+      if i = length then
+        false
+      else
+        match s.[i] with
+        | '#'
+        | '['
+        | '(' ->
+          true
+        | _ -> loop (i + 1)
+    in
+    loop 0
+  in
   let end_quoted =
     match last_char s with
     | Some '"' -> true
     | _ -> false in
-  if s = "" || (s.[0] == '"' && end_quoted) then
+  if (not may_have_reference) || (s.[0] == '"' && end_quoted) then
     []
   else
     match parse_string ~consume:All (Inline.parse config) s with


### PR DESCRIPTION
### Motivation
- Reduce allocations and work during outline parsing by reusing the strings produced by `String.split_on_char` instead of mapping and allocating new strings. 
- Avoid computing `line_starts` when only an outline parse is requested via `config.parse_outline_only`. 
- Avoid running the full inline grammar for property values that cannot contain references to improve performance on common scalar Logseq properties.

### Description
- In `lib/syntax/md_outline.ml` replace `Array.of_list (List.map rstrip_cr raw_lines)` with `Array.of_list raw_lines` and `Array.iteri` to only replace CRLF lines in place, reusing the original allocations for LF inputs. 
- Make `line_starts` allocation conditional on `config.parse_outline_only` so the array is not built when not needed. 
- In `lib/syntax/property.ml` add a cheap `may_have_reference` scan for `'#'`, `'['`, or `'('` and return early when none are present, and keep the existing quoted-string check; only run the full `Inline.parse` when a reference is plausible.

### Testing
- Ran the project test suite with `dune runtest`, and the tests completed successfully. 
- Performed quick parsing smoke tests on sample outlines and property lines to verify no regressions in outline extraction and property reference detection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a93c767e68c832cba83c5389f08294f)